### PR TITLE
Added workflow to publish package on npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to NPM
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup Yarn
+        run : npm install -g yarn && yarn cache clean
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build
+        run : yarn build
+
+      - name: Publish to NPM
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc && yarn publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
In this pull request, a new GitHub workflow has been added to publish a new package on NPM after merging or pushing changes to the `main` branch.

Closes issue #6. 

:warning: To make it work - `NPM_AUTH_TOKEN` secret should be added as a repo secret where value is an issued `publication` token from NPM. 