### PR TITLE
fix: remove eslint dependency

### DIFF
--- a/.changeset/chilly-ties-roll.md
+++ b/.changeset/chilly-ties-roll.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/react-providers": minor
+---
+
+Eslint dependency removed

--- a/packages/react-providers/package.json
+++ b/packages/react-providers/package.json
@@ -25,7 +25,6 @@
     "@polkadex/utils": "*",
     "@polkadot-cloud/assets": "^0.1.34",
     "@polkadot/keyring": "^12.5.1",
-    "eslint": "workspace:*",
     "typescript": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request implements the removal of the ESLint dependency from @polkadex/react-providers, as we have transitioned to using the @polkadex/eslint-config configuration.