### PR TITLE
fix: remove eslint dependency from all packages

### DIFF
--- a/.changeset/twelve-cats-look.md
+++ b/.changeset/twelve-cats-look.md
@@ -1,0 +1,9 @@
+---
+"@polkadex/trade-wallet": minor
+"@polkadex/react-hooks": minor
+"@polkadex/numericals": minor
+"@polkadex/types": minor
+"@polkadex/utils": minor
+---
+
+fix: remove eslint dependency from all packages

--- a/packages/numericals/package.json
+++ b/packages/numericals/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "bignumber": "^1.1.0",
-    "eslint": "workspace:*",
     "typescript": "latest"
   },
   "devDependencies": {

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@polkadex/utils": "*",
-    "eslint": "workspace:*",
     "typescript": "latest"
   },
   "devDependencies": {

--- a/packages/trade-wallet/package.json
+++ b/packages/trade-wallet/package.json
@@ -20,7 +20,6 @@
     "@polkadot/ui-keyring": "^3.6.4",
     "@polkadot/util-crypto": "^12.6.1",
     "bignumber": "^1.1.0",
-    "eslint": "workspace:*",
     "typescript": "latest"
   },
   "devDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -19,7 +19,6 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "eslint": "workspace:*",
     "typescript": "latest"
   },
   "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,11 +17,11 @@
   "dependencies": {
     "@polkadot/keyring": "^12.5.1",
     "@polkadot/util": "^12.5.1",
-    "eslint": "workspace:*",
     "typescript": "latest"
   },
   "devDependencies": {
-    "tsup": "^7.2.0"
+    "tsup": "^7.2.0",
+    "@polkadex/eslint-config": "*"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
This pull request implements the removal of the ESLint dependency from @polkadex/numericals, @polkadex/types, @polkadex/utils and @polkadex/trade-wallet as we have transitioned to using the @polkadex/eslint-config configuration.