### PR TITLE
Revert PR#52: Undo Client-Side Compatibility Fix in @polkadot-cloud/assets Package

### DIFF
--- a/.changeset/polite-countries-provide.md
+++ b/.changeset/polite-countries-provide.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/react-providers": minor
+---
+
+Revert PR#52: Undo Client-Side Compatibility Fix in @polkadot-cloud/assets Package

--- a/packages/react-providers/src/ExtensionsProvider/constants.ts
+++ b/packages/react-providers/src/ExtensionsProvider/constants.ts
@@ -7,5 +7,5 @@ export const defaultExtensionsContext: ExtensionsContextInterface = {
   removeExtensionStatus: (id) => {},
   extensionInstalled: (id) => false,
   extensionCanConnect: (id) => false,
-  extensionHasFeature: async (id, feature) => false,
+  extensionHasFeature: (id, feature) => false,
 };

--- a/packages/react-providers/src/ExtensionsProvider/provider.tsx
+++ b/packages/react-providers/src/ExtensionsProvider/provider.tsx
@@ -1,5 +1,6 @@
 import { createContext, ReactNode, useEffect, useRef, useState } from "react";
 import { setStateWithRef, AnyJson } from "@polkadex/utils";
+import { Extensions, ExtensionsArray } from "@polkadot-cloud/assets/extensions";
 
 import {
   ExtensionFeature,
@@ -41,7 +42,7 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
 
     if (hasInjectedWeb3 || snapAvailable)
       setStateWithRef(
-        await getExtensionsStatus(snapAvailable),
+        getExtensionsStatus(snapAvailable),
         setExtensionsStatus,
         extensionsStatusRef
       );
@@ -86,11 +87,8 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
   //
   // Loops through the supported extensios and checks if they are present in `injectedWeb3`. Adds
   // `installed` status to the extension if it is present.
-  const getExtensionsStatus = async (snapAvailable: boolean) => {
+  const getExtensionsStatus = (snapAvailable: boolean) => {
     const { injectedWeb3 }: AnyJson = window;
-    const { ExtensionsArray } = await import(
-      "@polkadot-cloud/assets/extensions"
-    );
 
     const newExtensionsStatus = { ...extensionsStatus };
     if (snapAvailable)
@@ -114,12 +112,10 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
     extensionInstalled(id) && extensionsStatus[id] !== "connected";
 
   // Checks whether an extension supports a feature.
-  const extensionHasFeature = async (
+  const extensionHasFeature = (
     id: string,
     feature: ExtensionFeature
-  ): Promise<boolean> => {
-    const { Extensions } = await import("@polkadot-cloud/assets/extensions");
-
+  ): boolean => {
     const features = Extensions[id].features;
     if (features === "*" || features.includes(feature)) return true;
     else return false;

--- a/packages/react-providers/src/ExtensionsProvider/types.ts
+++ b/packages/react-providers/src/ExtensionsProvider/types.ts
@@ -14,10 +14,7 @@ export interface ExtensionsContextInterface {
   removeExtensionStatus: (id: string) => void;
   extensionInstalled: (id: string) => boolean;
   extensionCanConnect: (id: string) => boolean;
-  extensionHasFeature: (
-    id: string,
-    feature: ExtensionFeature
-  ) => Promise<boolean>;
+  extensionHasFeature: (id: string, feature: ExtensionFeature) => boolean;
 }
 
 // Top level required properties the extension must expose via their `injectedWeb3` entry.


### PR DESCRIPTION
This pull request is a rollback of PR#52 "Resolve Client-Side Compatibility Issue in @polkadot-cloud/assets Package with Dynamic Import" The issue identified in PR#52 involved the enforcement of extension permissions during initialization when the package is dynamically called, leading to unforeseen challenges. This new PR aims to revert those changes and restoring the previous state.