### PR TITLE
Multistep Component: initial state for the current active step

### DIFF
--- a/.changeset/eighty-years-sip.md
+++ b/.changeset/eighty-years-sip.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/ux": minor
+---
+
+fix: change the default state when updating default options

--- a/packages/ui/src/components/multistep.tsx
+++ b/packages/ui/src/components/multistep.tsx
@@ -9,6 +9,7 @@ import {
   isValidElement,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import { usePrevious } from "react-use";
@@ -118,9 +119,10 @@ const Interactive = ({
 }: InteractiveProps) => {
   const [current, setCurrent] = useState(defaultIndex);
   const [active, setActive] = useState(defaultActive);
+  const initialIndex = useRef(defaultIndex).current;
+  const initialActive = useRef(defaultActive).current;
 
   const prevCount = usePrevious(current);
-
   const { refs, floatingStyles } = useFloating({
     whileElementsMounted: autoUpdate,
     middleware: [
@@ -201,6 +203,14 @@ const Interactive = ({
       onClickOutsideCallbackFn();
     setActive(false);
   }, [onClickOutsideCallbackFn]);
+
+  useEffect(() => {
+    if (defaultIndex !== initialIndex) setCurrent(defaultIndex);
+  }, [defaultIndex, defaultActive, initialIndex, initialActive]);
+
+  useEffect(() => {
+    if (defaultActive !== initialActive) setActive(defaultActive);
+  }, [defaultIndex, defaultActive, initialIndex, initialActive]);
 
   const portalProps = closeOnClickOutside
     ? {


### PR DESCRIPTION
## Description
Currently, default options changes in multistep are not retained, making it impossible to activate interactions manually. This PR addresses and corrects this issue.

## Screenshot 
Use case example
https://github.com/Polkadex-Substrate/polkadex-ts/assets/12574469/d9796154-178c-485a-805e-4314e6e1ca56

