### PR TITLE
Popconfirm component

### DIFF
--- a/.changeset/shy-lamps-impress.md
+++ b/.changeset/shy-lamps-impress.md
@@ -1,0 +1,7 @@
+---
+"@polkadex/ux": minor
+---
+
+- [x] feat: new PopConfirm component.
+- [x] fix: Some elements like buttons or text need a ref to be used within a popover
+- [x] fix: The type checking of components has been removed to reuse the popover

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,4 +1,10 @@
-import { ComponentProps, ElementType, PropsWithChildren } from "react";
+import {
+  ComponentProps,
+  ElementType,
+  PropsWithChildren,
+  PropsWithoutRef,
+  forwardRef,
+} from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
 import { Slot } from "@radix-ui/react-slot";
@@ -102,69 +108,94 @@ const variants = {
   },
 };
 
-const Base = ({
-  className,
-  asChild = false,
-  size = "default",
-  appearance = "primary",
-  variant = "solid",
-  withIcon = false,
-  rounded = false,
-  children,
-  ...props
-}: PropsWithChildren<ButtonProps>) => {
-  const Rendercomponent: ElementType = asChild ? Slot : "button";
-  return (
-    <Rendercomponent
-      className={twMerge(
-        classNames(
-          "transition-colors duration-300",
-          "flex items-center justify-center whitespace-nowrap",
-          "disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-disabled",
-          withIcon ? variants.iconSize[size] : variants.size[size],
-          rounded ? "rounded-full" : "rounded-sm",
-          withIcon && "group",
-          variants.color[variant][appearance]
-        ),
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </Rendercomponent>
-  );
-};
-
-const Solid = (props: PropsWithChildren<Omit<ButtonProps, "variant">>) => (
-  <Base variant="solid" {...props} />
+export const Base = forwardRef<
+  HTMLButtonElement | null,
+  PropsWithChildren<ButtonProps>
+>(
+  (
+    {
+      className,
+      asChild = false,
+      size = "default",
+      appearance = "primary",
+      variant = "solid",
+      withIcon = false,
+      rounded = false,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const Rendercomponent: ElementType = asChild ? Slot : "button";
+    return (
+      <Rendercomponent
+        ref={ref}
+        className={twMerge(
+          classNames(
+            "transition-colors duration-300",
+            "flex items-center justify-center whitespace-nowrap",
+            "disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-disabled",
+            withIcon ? variants.iconSize[size] : variants.size[size],
+            rounded ? "rounded-full" : "rounded-sm",
+            withIcon && "group",
+            variants.color[variant][appearance]
+          ),
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </Rendercomponent>
+    );
+  }
 );
+Base.displayName = "Base";
 
-const Ghost = ({
-  appearance = "secondary",
-  ...props
-}: PropsWithChildren<Omit<ButtonProps, "variant" | "withIcon">>) => (
-  <Base appearance={appearance} variant="ghost" {...props} />
-);
+const Solid = forwardRef<
+  HTMLButtonElement,
+  PropsWithoutRef<Omit<ButtonProps, "variant">>
+>((props, ref) => <Base ref={ref} variant="solid" {...props} />);
+Solid.displayName = "Solid";
 
-const Outline = (
-  props: PropsWithChildren<Omit<ButtonProps, "variant" | "withIcon">>
-) => <Base variant="outline" {...props} />;
+const Ghost = forwardRef<
+  HTMLButtonElement,
+  PropsWithoutRef<Omit<ButtonProps, "variant" | "withIcon">>
+>(({ appearance = "secondary", ...props }, ref) => (
+  <Base ref={ref} appearance={appearance} variant="ghost" {...props} />
+));
+Ghost.displayName = "Ghost";
 
-const Underline = (
-  props: PropsWithChildren<Omit<ButtonProps, "variant" | "withIcon">>
-) => <Base variant="underline" {...props} />;
+const Outline = forwardRef<
+  HTMLButtonElement,
+  PropsWithoutRef<Omit<ButtonProps, "variant" | "withIcon">>
+>((props, ref) => <Base ref={ref} variant="outline" {...props} />);
+Outline.displayName = "Outline";
 
-const Light = (
-  props: PropsWithChildren<Omit<ButtonProps, "variant" | "withIcon">>
-) => <Base variant="light" {...props} />;
+const Underline = forwardRef<
+  HTMLButtonElement,
+  PropsWithoutRef<Omit<ButtonProps, "variant" | "withIcon">>
+>((props, ref) => <Base ref={ref} variant="underline" {...props} />);
+Underline.displayName = "Underline";
 
-const Icon = ({
-  variant = "solid",
-  appearance = "secondary",
-  ...props
-}: PropsWithChildren<Omit<ButtonProps, "withIcon">>) => (
-  <Base variant={variant} appearance={appearance} withIcon {...props} />
-);
+const Light = forwardRef<
+  HTMLButtonElement,
+  PropsWithoutRef<Omit<ButtonProps, "variant" | "withIcon">>
+>((props, ref) => <Base ref={ref} variant="light" {...props} />);
+Light.displayName = "Light";
+
+const Icon = forwardRef<
+  HTMLButtonElement,
+  PropsWithoutRef<Omit<ButtonProps, "withIcon">>
+>(({ variant = "solid", appearance = "secondary", ...props }, ref) => (
+  <Base
+    ref={ref}
+    variant={variant}
+    appearance={appearance}
+    withIcon
+    {...props}
+  />
+));
+Icon.displayName = "Icon";
 
 export const Button = {
   Solid,

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -27,3 +27,4 @@ export * from "./table";
 export * from "./tabs";
 export * from "./label";
 export * from "./pagination";
+export * from "./popconfirm";

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -26,7 +26,7 @@ import { twMerge } from "tailwind-merge";
 import { isValidComponent } from "../helpers";
 
 import { Button as PolkadexButton } from "./button";
-import { Typography } from "./typography";
+import { TextProps, Typography } from "./typography";
 import { LabelProps, Label as LabelPolkadex } from "./label";
 
 const Base = forwardRef<ElementRef<"input">, ComponentPropsWithoutRef<"input">>(
@@ -102,9 +102,10 @@ const Button = ({ variant, ...props }: ButtonProps) => {
 
 const Ticker = ({
   children,
+  size = "sm",
   ...props
-}: PropsWithChildren<ComponentProps<"span">>) => (
-  <Typography.Text size="sm" {...props}>
+}: PropsWithChildren<TextProps>) => (
+  <Typography.Text size={size} {...props}>
     {children}
   </Typography.Text>
 );

--- a/packages/ui/src/components/interaction.tsx
+++ b/packages/ui/src/components/interaction.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, PropsWithChildren } from "react";
+import { ComponentProps, PropsWithChildren, PropsWithoutRef } from "react";
 import classNames from "classnames";
 import { ArrowLeftIcon, XMarkIcon } from "@heroicons/react/24/solid";
 import { twMerge } from "tailwind-merge";
@@ -85,11 +85,15 @@ const Footer = ({
   );
 };
 
-interface ActionProps extends ButtonProps, ComponentProps<"button"> {}
+type ActionProps = ButtonProps & ButtonProps;
 
-const Action = ({ children, ...props }: PropsWithChildren<ActionProps>) => {
+const Action = ({
+  children,
+  size = "md",
+  ...props
+}: PropsWithoutRef<ActionProps>) => {
   return (
-    <Button.Solid size="md" {...props}>
+    <Button.Solid size={size} {...props}>
       {children}
     </Button.Solid>
   );
@@ -97,10 +101,11 @@ const Action = ({ children, ...props }: PropsWithChildren<ActionProps>) => {
 
 const Close = ({
   children,
+  size = "md",
   ...props
-}: PropsWithChildren<ComponentProps<"button">>) => {
+}: PropsWithoutRef<ButtonProps>) => {
   return (
-    <Button.Ghost size="md" {...props}>
+    <Button.Ghost size={size} {...props}>
       {children}
     </Button.Ghost>
   );

--- a/packages/ui/src/components/pagination.tsx
+++ b/packages/ui/src/components/pagination.tsx
@@ -1,9 +1,13 @@
 import classNames from "classnames";
-import { ComponentProps, PropsWithChildren } from "react";
+import { ComponentProps, PropsWithChildren, PropsWithoutRef } from "react";
 import { twMerge } from "tailwind-merge";
 import * as Icons from "@heroicons/react/24/solid";
 
-import { Button as PolkadexButton, Typography } from "../components";
+import {
+  Button as PolkadexButton,
+  ButtonProps as PolkadexButtonProps,
+  Typography,
+} from "../components";
 
 interface PageProps extends ComponentProps<typeof Typography.Text> {
   currentPage: number;
@@ -36,20 +40,22 @@ const Ellipsis = ({
   );
 };
 
-interface ItemProps extends ComponentProps<"button"> {
+interface ItemProps extends PolkadexButtonProps {
   active?: boolean;
 }
 const Item = ({
   className,
   children = "Previous",
   active,
+  size = "sm",
+  appearance = "secondary",
   ...props
-}: PropsWithChildren<ItemProps>) => {
+}: PropsWithoutRef<ItemProps>) => {
   return (
     <PolkadexButton.Ghost
-      size="sm"
+      size={size}
       className={classNames(active && "bg-secondary-base", className)}
-      appearance="secondary"
+      appearance={appearance}
       {...props}
     >
       {children}
@@ -72,7 +78,7 @@ const Content = ({
   );
 };
 
-interface ButtonProps extends ComponentProps<"button"> {
+interface ButtonProps extends PolkadexButtonProps {
   arrowSide?: "left" | "right" | null;
   arrowType?: "double" | "single";
 }
@@ -82,8 +88,10 @@ const Button = ({
   children,
   arrowSide = null,
   arrowType = "single",
+  size = "sm",
+  appearance = "tertiary",
   ...props
-}: PropsWithChildren<ButtonProps>) => {
+}: PropsWithoutRef<ButtonProps>) => {
   const IconComponent =
     Icons[arrowType === "single" ? "ChevronLeftIcon" : "ChevronDoubleLeftIcon"];
 
@@ -91,9 +99,9 @@ const Button = ({
     <>
       {children ? (
         <PolkadexButton.Ghost
-          size="sm"
+          size={size}
           className={classNames("gap-1", className)}
-          appearance="tertiary"
+          appearance={appearance}
           {...props}
         >
           {arrowSide === "left" && (

--- a/packages/ui/src/components/popconfirm.tsx
+++ b/packages/ui/src/components/popconfirm.tsx
@@ -1,0 +1,150 @@
+import { PropsWithChildren, PropsWithoutRef } from "react";
+import { InformationCircleIcon } from "@heroicons/react/24/solid";
+import classNames from "classnames";
+import { twMerge } from "tailwind-merge";
+
+import { isValidComponent, typeofChildren } from "../helpers";
+
+import { Popover, PopoverContentProps, PopoverProps } from "./popover";
+import { TextProps, Typography } from "./typography";
+import { Base, ButtonProps } from "./button";
+
+const Close = ({
+  children,
+  variant = "ghost",
+  appearance = "secondary",
+  className = "px-4",
+  size = "2sm",
+  ...props
+}: PropsWithoutRef<ButtonProps>) => {
+  return (
+    <Popover.Close asChild>
+      <Base
+        variant={variant}
+        size={size}
+        appearance={appearance}
+        className={className}
+        {...props}
+      >
+        {children}
+      </Base>
+    </Popover.Close>
+  );
+};
+
+const Button = ({
+  children,
+  variant = "solid",
+  appearance = "primary",
+  className,
+  size = "2sm",
+  ...props
+}: PropsWithoutRef<ButtonProps>) => {
+  return (
+    <Base
+      variant={variant}
+      size={size}
+      appearance={appearance}
+      className={twMerge(classNames("px-4"), className)}
+      {...props}
+    >
+      {children}
+    </Base>
+  );
+};
+
+const Description = ({
+  children,
+  size = "sm",
+  appearance = "primary",
+  ...props
+}: PropsWithChildren<TextProps>) => {
+  const isString = typeofChildren(children);
+  return isString ? (
+    <Typography.Text size={size} appearance={appearance} {...props}>
+      {children}
+    </Typography.Text>
+  ) : (
+    children
+  );
+};
+
+const Title = ({
+  children,
+  size = "base",
+  bold = true,
+  ...props
+}: PropsWithChildren<TextProps>) => {
+  const isString = typeofChildren(children);
+  return isString ? (
+    <Typography.Text size={size} bold={bold} {...props}>
+      {children}
+    </Typography.Text>
+  ) : (
+    children
+  );
+};
+
+interface ContentProps extends PopoverContentProps {
+  withIcon?: boolean;
+}
+
+const Content = ({
+  children,
+  withIcon,
+  withArrow = true,
+  className,
+  ...props
+}: ContentProps) => {
+  const [TitleComponent] = isValidComponent(children, Title);
+  const [DescriptionComponent] = isValidComponent(children, Description);
+  const [ButtonComponent] = isValidComponent(children, Button);
+  const [CloseComponent] = isValidComponent(children, Close);
+
+  return (
+    <Popover.Content
+      className={twMerge(classNames("flex gap-2 p-4"), className)}
+      withArrow={withArrow}
+      {...props}
+    >
+      {withIcon && (
+        <InformationCircleIcon className="w-4 h-4 mt-1 text-attention-base" />
+      )}
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col">
+          {TitleComponent}
+          {DescriptionComponent}
+        </div>
+
+        <div className="flex-1 flex items-center justify-end gap-2 w-full">
+          {CloseComponent}
+          {ButtonComponent}
+        </div>
+      </div>
+    </Popover.Content>
+  );
+};
+
+const PopConfirm = ({
+  children,
+  ...props
+}: PropsWithChildren<PopoverProps>) => {
+  const [TriggerComponent] = isValidComponent(children, Popover.Trigger);
+  const [ContentComponent] = isValidComponent(children, Content);
+
+  return (
+    <Popover {...props}>
+      {TriggerComponent}
+      {ContentComponent}
+    </Popover>
+  );
+};
+
+PopConfirm.Trigger = Popover.Trigger;
+PopConfirm.Content = Content;
+PopConfirm.Button = Button;
+PopConfirm.Title = Title;
+PopConfirm.Description = Description;
+PopConfirm.Close = Close;
+
+export { PopConfirm };

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -1,87 +1,95 @@
 import * as PopoverRadix from "@radix-ui/react-popover";
-import { Fragment, PropsWithChildren } from "react";
+import { ComponentProps, Fragment, PropsWithChildren } from "react";
 import { twMerge } from "tailwind-merge";
 import classNames from "classnames";
-import { Slot } from "@radix-ui/react-slot";
 
-import { isValidComponent, typeofChildren } from "../helpers";
+import { typeofChildren } from "../helpers";
 
 const Close = ({
   children,
-  asChild,
   ...props
 }: PropsWithChildren<PopoverRadix.PopoverCloseProps>) => {
-  return (
-    <PopoverRadix.Close asChild={asChild} {...props}>
-      {asChild ? <Slot className="flex-1">{children}</Slot> : children}
-    </PopoverRadix.Close>
-  );
+  return <PopoverRadix.Close {...props}>{children}</PopoverRadix.Close>;
 };
 
-const Trigger = ({
-  children,
-  asChild,
-  className,
-  ...props
-}: PropsWithChildren<PopoverRadix.PopoverTriggerProps>) => {
+export type PopoverTriggerProps =
+  PropsWithChildren<PopoverRadix.PopoverTriggerProps>;
+const Trigger = ({ children, className, ...props }: PopoverTriggerProps) => {
   const isString = typeofChildren(children);
   return (
     <PopoverRadix.Trigger
-      asChild={asChild}
       className={twMerge(classNames(isString && "text-sm"), className)}
       {...props}
     >
-      {asChild ? <Slot>{children}</Slot> : children}
+      {children}
     </PopoverRadix.Trigger>
   );
 };
 
+export interface PopoverContentProps
+  extends PropsWithChildren<PopoverRadix.PopoverContentProps> {
+  withArrow?: boolean;
+  arrowProps?: PopoverRadix.PopoverArrowProps;
+  withOverlay?: boolean;
+  overlayProps?: ComponentProps<"div">;
+}
+
 const Content = ({
   children,
   className,
+  withArrow = false,
+  arrowProps,
+  withOverlay,
+  overlayProps,
   ...props
-}: PropsWithChildren<PopoverRadix.PopoverContentProps>) => {
+}: PopoverContentProps) => {
+  const { className: arrowClassname, ...restProps } = arrowProps || {};
+  const { className: overlayClassName, ...restOverlayProps } =
+    overlayProps ?? {};
+
   return (
-    <PopoverRadix.Content
-      className={twMerge(
-        classNames(
-          "z-50 shadow-md bg-level-1 rounded-md border border-primary min-w-[8rem]",
-          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95"
-        ),
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </PopoverRadix.Content>
+    <PopoverRadix.Portal>
+      <Fragment>
+        {withOverlay && (
+          <div
+            className={twMerge(
+              classNames(
+                "w-screen h-screen bg-overlay-3 inset-0 fixed animate-in"
+              ),
+              overlayClassName
+            )}
+            {...restOverlayProps}
+          />
+        )}
+        <PopoverRadix.Content
+          className={twMerge(
+            classNames(
+              "z-50 shadow-md bg-level-1 rounded-md border border-primary min-w-[8rem]",
+              "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+              "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95"
+            ),
+            className
+          )}
+          {...props}
+        >
+          <Fragment>
+            {children}
+            {withArrow && (
+              <PopoverRadix.Arrow
+                className={twMerge(classNames("fill-level-1"), arrowClassname)}
+                {...restProps}
+              />
+            )}
+          </Fragment>
+        </PopoverRadix.Content>
+      </Fragment>
+    </PopoverRadix.Portal>
   );
 };
+export type PopoverProps = PropsWithChildren<PopoverRadix.PopoverProps>;
 
-interface PopoverProps extends PopoverRadix.PopoverProps {
-  withOverlay?: boolean;
-}
-const Popover = ({
-  children,
-  withOverlay,
-  ...props
-}: PropsWithChildren<PopoverProps>) => {
-  const [TriggerComponent] = isValidComponent(children, Trigger);
-  const [ContentComponent] = isValidComponent(children, Content);
-
-  return (
-    <PopoverRadix.Root {...props}>
-      {TriggerComponent}
-      <PopoverRadix.Portal>
-        <Fragment>
-          {withOverlay && (
-            <div className="w-screen h-screen bg-overlay-3 inset-0 fixed animate-in" />
-          )}
-          {ContentComponent}
-        </Fragment>
-      </PopoverRadix.Portal>
-    </PopoverRadix.Root>
-  );
+const Popover = ({ children, ...props }: PopoverProps) => {
+  return <PopoverRadix.Root {...props}>{children}</PopoverRadix.Root>;
 };
 
 Popover.Trigger = Trigger;

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -52,13 +52,12 @@ const Cell = ({
         ),
         className
       )}
-      {...(!isString && props)}
+      {...props}
     >
       {isString ? (
         <Typography.Text
           size="sm"
           className={twMerge(classNames("font-normal"), className)}
-          {...props}
         >
           {children}
         </Typography.Text>
@@ -99,7 +98,7 @@ const Head = ({
           !isString && className
         )
       )}
-      {...(!isString && props)}
+      {...props}
     >
       {isString ? (
         <Typography.Text
@@ -109,7 +108,6 @@ const Head = ({
             classNames("font-normal", withArrow && "flex items-center gap-1"),
             className
           )}
-          {...props}
         >
           {children}
           {withArrow && (

--- a/packages/ui/src/components/typography.tsx
+++ b/packages/ui/src/components/typography.tsx
@@ -6,6 +6,7 @@ import {
   PropsWithChildren,
   ReactElement,
   cloneElement,
+  forwardRef,
 } from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
@@ -19,69 +20,80 @@ type Props = {
   asChild?: boolean;
 };
 
-interface TextProps extends ComponentPropsWithoutRef<"span">, Props {
+export interface TextProps extends ComponentPropsWithoutRef<"span">, Props {
   type?: "span" | "small" | "strong";
   bold?: boolean;
 }
 
-const Text = ({
-  children,
-  className,
-  appearance = "base",
-  size = "sm",
-  type = "span",
-  bold,
-  asChild,
-  ...props
-}: PropsWithChildren<TextProps>) => {
-  const ElementRender = asChild ? Slot : type;
+const Text = forwardRef<HTMLSpanElement, PropsWithChildren<TextProps>>(
+  (
+    {
+      children,
+      className,
+      appearance = "base",
+      size = "sm",
+      type = "span",
+      bold,
+      asChild,
+      ...props
+    },
+    ref
+  ) => {
+    const ElementRender = asChild ? Slot : type;
 
-  return (
-    <ElementRender
-      className={twMerge(
-        classNames(
-          bold && "font-semibold",
-          appearanceVariants[appearance],
-          fontSizes[size]
-        ),
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </ElementRender>
-  );
-};
+    return (
+      <ElementRender
+        ref={ref}
+        className={twMerge(
+          classNames(
+            bold && "font-semibold",
+            appearanceVariants[appearance],
+            fontSizes[size]
+          ),
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </ElementRender>
+    );
+  }
+);
+Text.displayName = "Text";
 
 type ParagraphProps = ComponentProps<"p"> & Props;
 
-const Paragraph = ({
-  children,
-  className,
-  appearance = "base",
-  size = "base",
-  ...props
-}: PropsWithChildren<ParagraphProps>) => {
-  const isChildrenParagraph = Children.toArray(children).some((child) =>
-    componentIsTypeof(child, "p")
-  );
-  const customClassNames = twMerge(
-    classNames("leading-5", appearanceVariants[appearance], fontSizes[size]),
-    className
-  );
-  if (isChildrenParagraph) {
-    const childElement = Children.only(children) as ReactElement;
-    return cloneElement(childElement, {
-      className: customClassNames,
-      ...props,
-    });
+const Paragraph = forwardRef<
+  HTMLParagraphElement,
+  PropsWithChildren<ParagraphProps>
+>(
+  (
+    { children, className, appearance = "base", size = "base", ...props },
+    ref
+  ) => {
+    const isChildrenParagraph = Children.toArray(children).some((child) =>
+      componentIsTypeof(child, "p")
+    );
+    const customClassNames = twMerge(
+      classNames("leading-5", appearanceVariants[appearance], fontSizes[size]),
+      className
+    );
+    if (isChildrenParagraph) {
+      const childElement = Children.only(children) as ReactElement;
+      return cloneElement(childElement, {
+        className: customClassNames,
+        ref,
+        ...props,
+      });
+    }
+    return (
+      <p ref={ref} className={customClassNames} {...props}>
+        {children}
+      </p>
+    );
   }
-  return (
-    <p className={customClassNames} {...props}>
-      {children}
-    </p>
-  );
-};
+);
+Paragraph.displayName = "Paragraph";
 
 interface HeadingProps extends ComponentProps<"h1"> {
   type?: (typeof headingTypes)[number];
@@ -91,31 +103,38 @@ interface HeadingProps extends ComponentProps<"h1"> {
 
 const headingTypes = ["h1", "h2", "h3", "h4", "h5", "h6"] as const;
 
-const Heading = ({
-  children,
-  className,
-  type = "h1",
-  size = "xl",
-  appearance = "base",
-  ...props
-}: PropsWithChildren<HeadingProps>) => {
-  const ElementRender = type as ElementType;
-  return (
-    <ElementRender
-      className={twMerge(
-        classNames(
-          "font-semibold",
-          fontSizes[size],
-          appearanceVariants[appearance]
-        ),
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </ElementRender>
-  );
-};
+const Heading = forwardRef<HTMLElement, PropsWithChildren<HeadingProps>>(
+  (
+    {
+      children,
+      className,
+      type = "h1",
+      size = "xl",
+      appearance = "base",
+      ...props
+    },
+    ref
+  ) => {
+    const ElementRender = type as ElementType;
+    return (
+      <ElementRender
+        ref={ref}
+        className={twMerge(
+          classNames(
+            "font-semibold",
+            fontSizes[size],
+            appearanceVariants[appearance]
+          ),
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </ElementRender>
+    );
+  }
+);
+Heading.displayName = "Heading";
 
 export const Typography = {
   Paragraph,


### PR DESCRIPTION
## Description

This PR introduces a new component named PopConfirm to enhance our user interface with a popover confirmation feature for swiftly confirming actions.

## Changes Made
- [x] feat: new PopConfirm component.
- [x] fix: Some elements like buttons or text need a ref to be used within a popover
- [x] fix: Some components, such as 'interaction' and 'table,' we are unable to pass the ref coming from 'ComponentProps.' Instead, we use 'componentWithoutRef'
- [x] fix: The type checking of components has been removed to reuse the popover

Close: https://github.com/Polkadex-Substrate/polkadex-ts/issues/94