### PR TITLE
Fix TypeScript Errors, Forward Refs, and Enhance Next.js Support

### DIFF
--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -1,8 +1,8 @@
 import {
   ComponentPropsWithoutRef,
   Fragment,
-  PropsWithChildren,
   forwardRef,
+  ElementRef,
 } from "react";
 import * as AccordionRadix from "@radix-ui/react-accordion";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
@@ -18,12 +18,11 @@ import { getRemainingComponents } from "../helpers/getRemainingComponents";
 
 import { Typography } from "./typography";
 
-const Icon = forwardRef<
-  SVGSVGElement,
-  PropsWithChildren<ComponentPropsWithoutRef<"svg">>
->(({ className, children, ...props }, ref) => {
-  return (
-    children ?? (
+const Icon = forwardRef<SVGSVGElement, ComponentPropsWithoutRef<"svg">>(
+  ({ className, children, ...props }, ref) => {
+    return children ? (
+      <Fragment>{children} </Fragment>
+    ) : (
       <ChevronDownIcon
         ref={ref}
         className={twMerge(
@@ -34,63 +33,64 @@ const Icon = forwardRef<
         )}
         {...props}
       />
-    )
-  );
-});
-Icon.displayName = "Icon";
-
-interface TriggerProps
-  extends PropsWithChildren<AccordionRadix.AccordionTriggerProps> {
-  superpositionTrigger?: boolean;
-  iconRotationAnimation?: boolean;
-}
-const Trigger = forwardRef<HTMLButtonElement, TriggerProps>(
-  ({ className, iconRotationAnimation = true, children, ...props }, ref) => {
-    const [IconComponent, RemaininigComponents] = isValidComponentWithoutTarget(
-      children,
-      Icon
-    );
-
-    const isString = typeofChildren(RemaininigComponents);
-    const renderComponent = getRemainingComponents(RemaininigComponents);
-
-    return (
-      <AccordionRadix.Header className="flex">
-        <AccordionRadix.Trigger
-          className={twMerge(
-            classNames(
-              "flex-1 flex justify-between align-center cursor-pointer",
-              !!IconComponent?.length &&
-                iconRotationAnimation &&
-                "[&[data-state=open]>svg]:rotate-180"
-            ),
-            className
-          )}
-          ref={ref}
-          {...props}
-        >
-          {!IconComponent ? (
-            children
-          ) : (
-            <Fragment>
-              {isString ? (
-                <Typography.Text>{renderComponent}</Typography.Text>
-              ) : (
-                renderComponent
-              )}
-              {IconComponent}
-            </Fragment>
-          )}
-        </AccordionRadix.Trigger>
-      </AccordionRadix.Header>
     );
   }
 );
+Icon.displayName = "Icon";
+
+interface TriggerProps
+  extends ComponentPropsWithoutRef<typeof AccordionRadix.Trigger> {
+  superpositionTrigger?: boolean;
+  iconRotationAnimation?: boolean;
+}
+const Trigger = forwardRef<
+  ElementRef<typeof AccordionRadix.Trigger>,
+  TriggerProps
+>(({ className, iconRotationAnimation = true, children, ...props }, ref) => {
+  const [IconComponent, RemaininigComponents] = isValidComponentWithoutTarget(
+    children,
+    Icon
+  );
+
+  const isString = typeofChildren(RemaininigComponents);
+  const renderComponent = getRemainingComponents(RemaininigComponents);
+
+  return (
+    <AccordionRadix.Header className="flex">
+      <AccordionRadix.Trigger
+        className={twMerge(
+          classNames(
+            "flex-1 flex justify-between align-center cursor-pointer",
+            !!IconComponent?.length &&
+              iconRotationAnimation &&
+              "[&[data-state=open]>svg]:rotate-180"
+          ),
+          className
+        )}
+        ref={ref}
+        {...props}
+      >
+        {!IconComponent ? (
+          children
+        ) : (
+          <Fragment>
+            {isString ? (
+              <Typography.Text>{renderComponent}</Typography.Text>
+            ) : (
+              renderComponent
+            )}
+            {IconComponent}
+          </Fragment>
+        )}
+      </AccordionRadix.Trigger>
+    </AccordionRadix.Header>
+  );
+});
 Trigger.displayName = "Trigger";
 
 const Content = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<AccordionRadix.AccordionContentProps>
+  ElementRef<typeof AccordionRadix.Content>,
+  ComponentPropsWithoutRef<typeof AccordionRadix.Content>
 >(({ className, children, ...props }, ref) => {
   return (
     <AccordionRadix.Content
@@ -112,8 +112,8 @@ const Content = forwardRef<
 Content.displayName = "Content";
 
 const Item = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<AccordionRadix.AccordionItemProps>
+  ElementRef<typeof AccordionRadix.Item>,
+  ComponentPropsWithoutRef<typeof AccordionRadix.Item>
 >(({ children, ...props }, ref) => {
   const [TriggerComponent] = isValidComponent(children, Trigger);
   const [ContentComponent] = isValidComponent(children, Content);
@@ -131,9 +131,7 @@ const Accordion = ({
   children,
   className,
   ...props
-}: PropsWithChildren<
-  AccordionRadix.AccordionSingleProps | AccordionRadix.AccordionMultipleProps
->) => {
+}: ComponentPropsWithoutRef<typeof AccordionRadix.Root>) => {
   const items = isValidComponent(children, Item);
 
   return (

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   ComponentPropsWithoutRef,
   Fragment,

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   ComponentProps,
   ElementType,

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
 import * as CheckboxRadix from "@radix-ui/react-checkbox";
 import classNames from "classnames";

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,21 +1,19 @@
-import { PropsWithChildren } from "react";
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
 import * as CheckboxRadix from "@radix-ui/react-checkbox";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
 
 import { Check } from "../icons";
 
-import { LabelProps, Label as LabelPolkadex } from "./label";
+import { Label as LabelPolkadex } from "./label";
 
-const Base = ({
-  className,
-  children,
-  disabled,
-  id,
-  ...props
-}: PropsWithChildren<CheckboxRadix.CheckboxProps>) => (
+const Base = forwardRef<
+  ElementRef<typeof CheckboxRadix.Root>,
+  ComponentPropsWithoutRef<typeof CheckboxRadix.Root>
+>(({ className, children, disabled, id, ...props }, ref) => (
   <div className={"flex items-center gap-2 group"}>
     <CheckboxRadix.Root
+      ref={ref}
       id={id}
       disabled={disabled}
       className={twMerge(
@@ -34,21 +32,23 @@ const Base = ({
     </CheckboxRadix.Root>
     {children}
   </div>
-);
+));
+Base.displayName = "Base";
 
-const Label = ({
-  appearance = "base",
-  size = "sm",
-  ...props
-}: PropsWithChildren<LabelProps>) => (
-  <LabelPolkadex appearance={appearance} size={size} {...props} />
-);
+const Label = forwardRef<
+  ElementRef<typeof LabelPolkadex>,
+  ComponentPropsWithoutRef<typeof LabelPolkadex>
+>(({ appearance = "base", size = "sm", ...props }, ref) => (
+  <LabelPolkadex ref={ref} appearance={appearance} size={size} {...props} />
+));
+Label.displayName = "Label";
 
-const Solid = ({
-  className,
-  ...props
-}: PropsWithChildren<CheckboxRadix.CheckboxProps>) => (
+const Solid = forwardRef<
+  ElementRef<typeof CheckboxRadix.Root>,
+  ComponentPropsWithoutRef<typeof CheckboxRadix.Root>
+>(({ className, ...props }, ref) => (
   <Base
+    ref={ref}
     className={twMerge(
       classNames(
         "data-[state=unchecked]:bg-level-5 data-[state=unchecked]:group-hover:bg-level-2 border-none",
@@ -58,13 +58,15 @@ const Solid = ({
     )}
     {...props}
   />
-);
+));
+Solid.displayName = "Solid";
 
-const Outline = ({
-  className,
-  ...props
-}: PropsWithChildren<CheckboxRadix.CheckboxProps>) => (
+const Outline = forwardRef<
+  ElementRef<typeof CheckboxRadix.Root>,
+  ComponentPropsWithoutRef<typeof CheckboxRadix.Root>
+>(({ className, ...props }, ref) => (
   <Base
+    ref={ref}
     className={twMerge(
       classNames(
         "border-2 border-primary data-[state=unchecked]:group-hover:border-current",
@@ -74,7 +76,9 @@ const Outline = ({
     )}
     {...props}
   />
-);
+));
+Outline.displayName = "Outline";
+
 export const Checkbox = {
   Solid,
   Outline,

--- a/packages/ui/src/components/copy.tsx
+++ b/packages/ui/src/components/copy.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ComponentProps, MouseEvent, PropsWithChildren, useState } from "react";
 import { DocumentDuplicateIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";

--- a/packages/ui/src/components/drawer.tsx
+++ b/packages/ui/src/components/drawer.tsx
@@ -32,17 +32,11 @@ const Title = ({
   );
 };
 
-const Footer = ({
-  children,
-  ...props
-}: PropsWithChildren<ComponentProps<"div">>) => {
+const Footer = ({ children, ...props }: ComponentProps<"div">) => {
   return <div {...props}>{children}</div>;
 };
 
-const Content = ({
-  children,
-  ...props
-}: PropsWithChildren<ComponentProps<"div">>) => {
+const Content = ({ children, ...props }: ComponentProps<"div">) => {
   return <div {...props}>{children}</div>;
 };
 

--- a/packages/ui/src/components/drawer.tsx
+++ b/packages/ui/src/components/drawer.tsx
@@ -1,5 +1,4 @@
-// shouldScaleBackground Requires vaul-drawer-wrapper data-attr
-
+"use client";
 import {
   ComponentProps,
   PropsWithChildren,

--- a/packages/ui/src/components/dropdown.tsx
+++ b/packages/ui/src/components/dropdown.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
   Children,

--- a/packages/ui/src/components/dropdown.tsx
+++ b/packages/ui/src/components/dropdown.tsx
@@ -1,11 +1,11 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
   Children,
-  ComponentPropsWithRef,
   ComponentPropsWithoutRef,
   Fragment,
   PropsWithChildren,
   forwardRef,
+  ElementRef,
 } from "react";
 import { CheckIcon } from "@heroicons/react/24/outline";
 import { twMerge } from "tailwind-merge";
@@ -22,39 +22,39 @@ import { getRemainingComponents } from "../helpers/getRemainingComponents";
 
 import { Typography } from "./typography";
 
-const Overlay = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<ComponentPropsWithRef<"div">>
->(({ className, ...props }, ref) => {
-  return (
-    <Transition
-      show
-      enter="duration-300 ease-out"
-      enter-from="opacity-0"
-      enter-to="opacity-100"
-      leave="duration-200 ease-in"
-      leave-from="opacity-100"
-      leave-to="opacity-0"
-    >
-      <div
-        ref={ref}
-        className={twMerge(
-          classNames("w-screen h-screen bg-overlay-3 inset-0 fixed animate-in"),
-          className
-        )}
-        {...props}
-      />
-    </Transition>
-  );
-});
+const Overlay = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<"div">>(
+  ({ className, ...props }, ref) => {
+    return (
+      <Transition
+        show
+        enter="duration-300 ease-out"
+        enter-from="opacity-0"
+        enter-to="opacity-100"
+        leave="duration-200 ease-in"
+        leave-from="opacity-100"
+        leave-to="opacity-0"
+      >
+        <div
+          ref={ref}
+          className={twMerge(
+            classNames(
+              "w-screen h-screen bg-overlay-3 inset-0 fixed animate-in"
+            ),
+            className
+          )}
+          {...props}
+        />
+      </Transition>
+    );
+  }
+);
 Overlay.displayName = "Overlay";
 
-const Icon = forwardRef<
-  SVGSVGElement,
-  PropsWithChildren<ComponentPropsWithoutRef<"svg">>
->(({ className, children, ...props }, ref) => {
-  return (
-    children ?? (
+const Icon = forwardRef<SVGSVGElement, ComponentPropsWithoutRef<"svg">>(
+  ({ className, children, ...props }, ref) => {
+    return children ? (
+      <Fragment>{children} </Fragment>
+    ) : (
       <ChevronDownIcon
         ref={ref}
         className={twMerge(
@@ -63,14 +63,14 @@ const Icon = forwardRef<
         )}
         {...props}
       />
-    )
-  );
-});
+    );
+  }
+);
 Icon.displayName = "Icon";
 
 const Radio = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<DropdownMenu.MenuRadioGroupProps>
+  ElementRef<typeof DropdownMenu.RadioGroup>,
+  ComponentPropsWithoutRef<typeof DropdownMenu.RadioGroup>
 >(({ children, ...props }, ref) => {
   const items = Children.toArray(children);
 
@@ -81,46 +81,44 @@ const Radio = forwardRef<
   );
 });
 Radio.displayName = "Radio";
-interface ItemRadioProps extends DropdownMenu.MenuRadioItemProps {
-  active?: boolean;
-}
 
-const ItemRadio = forwardRef<HTMLDivElement, PropsWithChildren<ItemRadioProps>>(
-  ({ children, className, active, ...props }, ref) => {
-    const isString = typeofChildren(children);
+const ItemRadio = forwardRef<
+  ElementRef<typeof DropdownMenu.RadioItem>,
+  ComponentPropsWithoutRef<typeof DropdownMenu.RadioItem> & { active?: boolean }
+>(({ children, className, active, ...props }, ref) => {
+  const isString = typeofChildren(children);
 
-    return (
-      <DropdownMenu.RadioItem
-        ref={ref}
-        className={twMerge(
-          classNames(
-            "p-2 m-1 flex items-center gap-2 outline-none cursor-default",
-            "transition-colors duration-300 focus:bg-level-3 rounded-md",
-            "data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
-          ),
-          className
-        )}
-        {...props}
-      >
-        <Fragment>
-          <div
-            className={classNames(
-              active ? "bg-primary-base" : "bg-level-4",
-              "w-1.5 h-1.5 rounded-full"
-            )}
-          />
-          {(isString && <Typography.Text>{children}</Typography.Text>) ||
-            children}
-        </Fragment>
-      </DropdownMenu.RadioItem>
-    );
-  }
-);
+  return (
+    <DropdownMenu.RadioItem
+      ref={ref}
+      className={twMerge(
+        classNames(
+          "p-2 m-1 flex items-center gap-2 outline-none cursor-default",
+          "transition-colors duration-300 focus:bg-level-3 rounded-md",
+          "data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
+        ),
+        className
+      )}
+      {...props}
+    >
+      <Fragment>
+        <div
+          className={classNames(
+            active ? "bg-primary-base" : "bg-level-4",
+            "w-1.5 h-1.5 rounded-full"
+          )}
+        />
+        {(isString && <Typography.Text>{children}</Typography.Text>) ||
+          children}
+      </Fragment>
+    </DropdownMenu.RadioItem>
+  );
+});
 ItemRadio.displayName = "ItemRadio";
 
 const ItemCheckbox = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<DropdownMenu.MenuCheckboxItemProps>
+  ElementRef<typeof DropdownMenu.CheckboxItem>,
+  ComponentPropsWithoutRef<typeof DropdownMenu.CheckboxItem>
 >(({ children, className, checked, ...props }, ref) => {
   const isString = typeofChildren(children);
 
@@ -148,45 +146,44 @@ const ItemCheckbox = forwardRef<
 });
 ItemCheckbox.displayName = "ItemCheckbox";
 
-interface ItemProps extends DropdownMenu.MenuItemProps {
-  shortcut?: string;
-}
+const Item = forwardRef<
+  ElementRef<typeof DropdownMenu.Item>,
+  ComponentPropsWithoutRef<typeof DropdownMenu.Item> & { shortcut?: string }
+>(({ children, shortcut, className, ...props }, ref) => {
+  const isString = typeofChildren(children);
 
-const Item = forwardRef<HTMLDivElement, PropsWithChildren<ItemProps>>(
-  ({ children, shortcut, className, ...props }, ref) => {
-    const isString = typeofChildren(children);
-
-    return (
-      <DropdownMenu.Item
-        ref={ref}
-        className={twMerge(
-          classNames(
-            "p-2 m-1 flex justify-between gap-4 outline-none cursor-default",
-            "transition-colors duration-300 focus:bg-level-3 rounded-md",
-            "data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
-          ),
-          className
-        )}
-        {...props}
-      >
-        <Fragment>
-          {(isString && <Typography.Text>{children}</Typography.Text>) ||
-            children}
-          {shortcut && <span className="text-sm opacity-50">{shortcut}</span>}
-        </Fragment>
-      </DropdownMenu.Item>
-    );
-  }
-);
+  return (
+    <DropdownMenu.Item
+      ref={ref}
+      className={twMerge(
+        classNames(
+          "p-2 m-1 flex justify-between gap-4 outline-none cursor-default",
+          "transition-colors duration-300 focus:bg-level-3 rounded-md",
+          "data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
+        ),
+        className
+      )}
+      {...props}
+    >
+      <Fragment>
+        {(isString && <Typography.Text>{children}</Typography.Text>) ||
+          children}
+        {shortcut && <span className="text-sm opacity-50">{shortcut}</span>}
+      </Fragment>
+    </DropdownMenu.Item>
+  );
+});
 Item.displayName = "Item";
 
-interface DropdownTriggerProps extends DropdownMenu.DropdownMenuTriggerProps {
+interface DropdownTriggerProps
+  extends ComponentPropsWithoutRef<typeof DropdownMenu.Trigger> {
   superpositionTrigger?: boolean;
   iconRotationAnimation?: boolean;
 }
+
 const Trigger = forwardRef<
-  HTMLButtonElement,
-  PropsWithChildren<DropdownTriggerProps>
+  ElementRef<typeof DropdownMenu.Trigger>,
+  DropdownTriggerProps
 >(
   (
     {
@@ -242,8 +239,8 @@ const Trigger = forwardRef<
 Trigger.displayName = "Trigger";
 
 const Content = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<DropdownMenu.MenuContentProps>
+  ElementRef<typeof DropdownMenu.Content>,
+  ComponentPropsWithoutRef<typeof DropdownMenu.Content>
 >(({ children, className, sideOffset = 10, ...props }, ref) => {
   return (
     <DropdownMenu.Content
@@ -268,7 +265,7 @@ Content.displayName = "Content";
 const Sub = ({
   children,
   ...props
-}: PropsWithChildren<DropdownMenu.MenuSubContentProps>) => {
+}: PropsWithChildren<typeof DropdownMenu.Sub>) => {
   const [SubTriggerComponent] = isValidComponent(children, SubTrigger);
   const [SubContentComponent] = isValidComponent(children, SubContent);
 
@@ -281,8 +278,8 @@ const Sub = ({
 };
 
 const SubTrigger = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<DropdownMenu.MenuSubTriggerProps>
+  ElementRef<typeof DropdownMenu.SubTrigger>,
+  ComponentPropsWithoutRef<typeof DropdownMenu.SubTrigger>
 >(({ children, ...props }, ref) => {
   return (
     <DropdownMenu.SubTrigger ref={ref} {...props}>
@@ -293,8 +290,8 @@ const SubTrigger = forwardRef<
 SubTrigger.displayName = "SubTrigger";
 
 const SubContent = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<DropdownMenu.MenuSubContentProps>
+  ElementRef<typeof DropdownMenu.SubContent>,
+  ComponentPropsWithoutRef<typeof DropdownMenu.SubContent>
 >(({ children, ...props }, ref) => {
   return (
     <DropdownMenu.SubContent ref={ref} {...props}>
@@ -305,8 +302,8 @@ const SubContent = forwardRef<
 SubContent.displayName = "SubContent";
 
 const Separator = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<DropdownMenu.MenuSeparatorProps>
+  ElementRef<typeof DropdownMenu.Separator>,
+  ComponentPropsWithoutRef<typeof DropdownMenu.Separator>
 >(({ children, className, ...props }, ref) => {
   return (
     <DropdownMenu.Separator
@@ -321,8 +318,8 @@ const Separator = forwardRef<
 Separator.displayName = "Separator";
 
 const Label = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<DropdownMenu.MenuLabelProps>
+  ElementRef<typeof DropdownMenu.Label>,
+  ComponentPropsWithoutRef<typeof DropdownMenu.Label>
 >(({ children, className, ...props }, ref) => {
   const isString = typeofChildren(children);
 

--- a/packages/ui/src/components/genericMessage.tsx
+++ b/packages/ui/src/components/genericMessage.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ComponentProps, PropsWithChildren } from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";

--- a/packages/ui/src/components/hoverCard.tsx
+++ b/packages/ui/src/components/hoverCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as HoverCardRadix from "@radix-ui/react-hover-card";
 import {
   ComponentPropsWithoutRef,

--- a/packages/ui/src/components/hoverCard.tsx
+++ b/packages/ui/src/components/hoverCard.tsx
@@ -1,57 +1,79 @@
 import * as HoverCardRadix from "@radix-ui/react-hover-card";
-import { Fragment, PropsWithChildren } from "react";
+import {
+  ComponentPropsWithoutRef,
+  ElementRef,
+  forwardRef,
+  Fragment,
+  PropsWithChildren,
+} from "react";
 import { twMerge } from "tailwind-merge";
 import classNames from "classnames";
 
 import { isValidComponent } from "../helpers";
 
-const Trigger = ({
-  children,
-  ...props
-}: PropsWithChildren<HoverCardRadix.HoverCardTriggerProps>) => {
-  return <HoverCardRadix.Trigger {...props}>{children}</HoverCardRadix.Trigger>;
-};
+const Trigger = forwardRef<
+  ElementRef<typeof HoverCardRadix.Trigger>,
+  ComponentPropsWithoutRef<typeof HoverCardRadix.Trigger>
+>(({ children, ...props }, ref) => {
+  return (
+    <HoverCardRadix.Trigger ref={ref} {...props}>
+      {children}
+    </HoverCardRadix.Trigger>
+  );
+});
+Trigger.displayName = "Trigger";
 
-interface ContentProps extends HoverCardRadix.HoverCardContentProps {
+interface ContentProps
+  extends ComponentPropsWithoutRef<typeof HoverCardRadix.Content> {
   withArrow?: boolean;
   arrowProps?: HoverCardRadix.HoverCardArrowProps;
 }
-const Content = ({
-  children,
-  className,
-  sideOffset = 12,
-  withArrow = true,
-  arrowProps,
-  ...props
-}: PropsWithChildren<ContentProps>) => {
-  const { className: arrowClassname, ...restProps } = arrowProps || {};
 
-  return (
-    <HoverCardRadix.Content
-      sideOffset={sideOffset}
-      className={twMerge(
-        classNames(
-          "p-2 bg-level-1 rounded-md border border-primary text-sm",
-          "z-50 overflow-hidden shadow-md animate-in fade-in-0 zoom-in-95 ",
-          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95"
-        ),
-        className
-      )}
-      {...props}
-    >
-      <Fragment>
-        {children}
-        {withArrow && (
-          <HoverCardRadix.Arrow
-            className={twMerge(classNames("fill-level-1"), arrowClassname)}
-            {...restProps}
-          />
+const Content = forwardRef<
+  ElementRef<typeof HoverCardRadix.Content>,
+  ContentProps
+>(
+  (
+    {
+      children,
+      className,
+      sideOffset = 12,
+      withArrow = true,
+      arrowProps,
+      ...props
+    },
+    ref
+  ) => {
+    const { className: arrowClassname, ...restProps } = arrowProps || {};
+    return (
+      <HoverCardRadix.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={twMerge(
+          classNames(
+            "p-2 bg-level-1 rounded-md border border-primary text-sm",
+            "z-50 overflow-hidden shadow-md animate-in fade-in-0 zoom-in-95 ",
+            "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+            "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95"
+          ),
+          className
         )}
-      </Fragment>
-    </HoverCardRadix.Content>
-  );
-};
+        {...props}
+      >
+        <Fragment>
+          {children}
+          {withArrow && (
+            <HoverCardRadix.Arrow
+              className={twMerge(classNames("fill-level-1"), arrowClassname)}
+              {...restProps}
+            />
+          )}
+        </Fragment>
+      </HoverCardRadix.Content>
+    );
+  }
+);
+Content.displayName = "Content";
 
 const HoverCard = ({
   children,

--- a/packages/ui/src/components/icon.tsx
+++ b/packages/ui/src/components/icon.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ComponentProps, PropsWithChildren } from "react";
 import { twMerge } from "tailwind-merge";
 import classNames from "classnames";

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   MagnifyingGlassIcon,
   MinusIcon,

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -17,6 +17,7 @@ import {
   useMemo,
   useRef,
   useState,
+  Fragment,
 } from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
@@ -67,7 +68,7 @@ Base.displayName = "Base";
 
 const Primary = forwardRef<
   ElementRef<"input">,
-  PropsWithChildren<ComponentPropsWithoutRef<"input">>
+  ComponentPropsWithoutRef<"input">
 >(({ children, ...props }) => {
   const ref = useRef<HTMLInputElement>(null);
   const ButtonComponents = isValidComponent(children, Button);
@@ -108,19 +109,19 @@ const Button = ({
   children,
   ...props
 }: PropsWithChildren<ButtonProps>) => {
-  return (
-    children ?? (
-      <button
-        className="rounded-tr flex-auto px-3 bg-level-4 hover:bg-level-2 duration-300 transition-colors ease-out"
-        {...props}
-      >
-        {variant === "increase" ? (
-          <PlusIcon className="w-3 h-3" />
-        ) : (
-          <MinusIcon className="w-3 h-3" />
-        )}
-      </button>
-    )
+  return children ? (
+    <Fragment>{children} </Fragment>
+  ) : (
+    <button
+      className="rounded-tr flex-auto px-3 bg-level-4 hover:bg-level-2 duration-300 transition-colors ease-out"
+      {...props}
+    >
+      {variant === "increase" ? (
+        <PlusIcon className="w-3 h-3" />
+      ) : (
+        <MinusIcon className="w-3 h-3" />
+      )}
+    </button>
   );
 };
 
@@ -159,7 +160,7 @@ const Vertical = ({
   id,
   children,
   ...props
-}: PropsWithChildren<ComponentPropsWithoutRef<"input">>) => {
+}: ComponentPropsWithoutRef<"input">) => {
   const LabelComponent = isValidComponent(children, Label);
   const ButtonComponent = isValidComponent(children, Action);
 

--- a/packages/ui/src/components/interaction.tsx
+++ b/packages/ui/src/components/interaction.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   ComponentProps,
   Fragment,

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -1,4 +1,6 @@
-import { ComponentProps, PropsWithChildren } from "react";
+"use client";
+
+import { ComponentProps } from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
 
@@ -15,7 +17,7 @@ export const Label = ({
   appearance = "primary",
   size = "sm",
   ...props
-}: PropsWithChildren<LabelProps>) => (
+}: LabelProps) => (
   <label
     className={twMerge(
       classNames(

--- a/packages/ui/src/components/loading.tsx
+++ b/packages/ui/src/components/loading.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Fragment, PropsWithChildren } from "react";
 
 import { Spinner as CustomSpinner } from "./spinner";

--- a/packages/ui/src/components/logo.tsx
+++ b/packages/ui/src/components/logo.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ComponentProps } from "react";
 
 const Thea = (props: ComponentProps<"svg">) => (

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   ComponentProps,
   ComponentPropsWithoutRef,

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -35,17 +35,11 @@ const Title = forwardRef<
 });
 Title.displayName = "Title";
 
-const Footer = ({
-  children,
-  ...props
-}: PropsWithChildren<ComponentProps<"div">>) => {
+const Footer = ({ children, ...props }: ComponentProps<"div">) => {
   return <div {...props}>{children}</div>;
 };
 
-const Content = ({
-  children,
-  ...props
-}: PropsWithChildren<ComponentProps<"div">>) => {
+const Content = ({ children, ...props }: ComponentProps<"div">) => {
   return <div {...props}>{children}</div>;
 };
 

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -1,5 +1,8 @@
 import {
   ComponentProps,
+  ComponentPropsWithoutRef,
+  ElementRef,
+  forwardRef,
   PropsWithChildren,
   useEffect,
   useRef,
@@ -15,11 +18,10 @@ interface TitleProps extends AlertDialog.DialogTitleProps {
   onBack?: () => void;
 }
 
-const Title = ({
-  children,
-  className,
-  ...props
-}: PropsWithChildren<TitleProps>) => {
+const Title = forwardRef<
+  ElementRef<typeof AlertDialog.Title>,
+  ComponentPropsWithoutRef<typeof AlertDialog.Title>
+>(({ children, className, ...props }: PropsWithChildren<TitleProps>) => {
   return (
     <AlertDialog.Title
       className={twMerge(classNames("flex items-center gap-2"), className)}
@@ -28,7 +30,8 @@ const Title = ({
       {children}
     </AlertDialog.Title>
   );
-};
+});
+Title.displayName = "Title";
 
 const Footer = ({
   children,

--- a/packages/ui/src/components/multistep.tsx
+++ b/packages/ui/src/components/multistep.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Children,
   ComponentProps,

--- a/packages/ui/src/components/pagination.tsx
+++ b/packages/ui/src/components/pagination.tsx
@@ -65,11 +65,7 @@ const Item = ({
   );
 };
 
-const Content = ({
-  className,
-  children,
-  ...props
-}: PropsWithChildren<ComponentProps<"div">>) => {
+const Content = ({ className, children, ...props }: ComponentProps<"div">) => {
   return (
     <div
       className={classNames("flex gap-1 items-center", className)}
@@ -131,7 +127,7 @@ const Pagination = ({
   className,
   children,
   ...props
-}: PropsWithChildren<ComponentProps<"nav">>) => {
+}: ComponentProps<"nav">) => {
   return (
     <nav
       role="navigation"

--- a/packages/ui/src/components/pagination.tsx
+++ b/packages/ui/src/components/pagination.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import classNames from "classnames";
 import { ComponentProps, PropsWithChildren, PropsWithoutRef } from "react";
 import { twMerge } from "tailwind-merge";

--- a/packages/ui/src/components/popconfirm.tsx
+++ b/packages/ui/src/components/popconfirm.tsx
@@ -1,8 +1,14 @@
-import { Fragment, PropsWithChildren, PropsWithoutRef } from "react";
+import {
+  ComponentPropsWithoutRef,
+  ElementRef,
+  forwardRef,
+  Fragment,
+  PropsWithChildren,
+  PropsWithoutRef,
+} from "react";
 import { InformationCircleIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
-import * as PopoverRadix from "@radix-ui/react-popover";
 
 import {
   isValidComponent,
@@ -11,7 +17,7 @@ import {
 } from "../helpers";
 import { getRemainingComponents } from "../helpers/getRemainingComponents";
 
-import { Popover, PopoverContentProps, PopoverProps } from "./popover";
+import { Popover, PopoverProps } from "./popover";
 import { TextProps, Typography } from "./typography";
 import { Base, ButtonProps } from "./button";
 
@@ -71,7 +77,7 @@ const Description = ({
       {children}
     </Typography.Text>
   ) : (
-    children
+    <Fragment>{children}</Fragment>
   );
 };
 
@@ -87,49 +93,48 @@ const Title = ({
       {children}
     </Typography.Text>
   ) : (
-    children
+    <Fragment>{children}</Fragment>
   );
 };
 
-interface ContentProps extends PopoverContentProps {
+interface ContentProps
+  extends ComponentPropsWithoutRef<typeof Popover.Content> {
   withIcon?: boolean;
 }
 
-const Content = ({
-  children,
-  withIcon,
-  withArrow = true,
-  className,
-  ...props
-}: ContentProps) => {
-  const [TitleComponent] = isValidComponent(children, Title);
-  const [DescriptionComponent] = isValidComponent(children, Description);
-  const [ButtonComponent] = isValidComponent(children, Button);
-  const [CloseComponent] = isValidComponent(children, Close);
+const Content = forwardRef<ElementRef<typeof Popover.Content>, ContentProps>(
+  ({ children, withIcon, withArrow = true, className, ...props }, ref) => {
+    const [TitleComponent] = isValidComponent(children, Title);
+    const [DescriptionComponent] = isValidComponent(children, Description);
+    const [ButtonComponent] = isValidComponent(children, Button);
+    const [CloseComponent] = isValidComponent(children, Close);
 
-  return (
-    <Popover.Content
-      className={twMerge(classNames("flex gap-2 p-4"), className)}
-      withArrow={withArrow}
-      {...props}
-    >
-      {withIcon && (
-        <InformationCircleIcon className="w-4 h-4 mt-1 text-attention-base" />
-      )}
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col">
-          {TitleComponent}
-          {DescriptionComponent}
-        </div>
+    return (
+      <Popover.Content
+        ref={ref}
+        className={twMerge(classNames("flex gap-2 p-4"), className)}
+        withArrow={withArrow}
+        {...props}
+      >
+        {withIcon && (
+          <InformationCircleIcon className="w-4 h-4 mt-1 text-attention-base" />
+        )}
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col">
+            {TitleComponent}
+            {DescriptionComponent}
+          </div>
 
-        <div className="flex-1 flex items-center justify-end gap-2 w-full">
-          {CloseComponent}
-          {ButtonComponent}
+          <div className="flex-1 flex items-center justify-end gap-2 w-full">
+            {CloseComponent}
+            {ButtonComponent}
+          </div>
         </div>
-      </div>
-    </Popover.Content>
-  );
-};
+      </Popover.Content>
+    );
+  }
+);
+Content.displayName = "Content";
 
 const PopConfirm = ({
   children,

--- a/packages/ui/src/components/popconfirm.tsx
+++ b/packages/ui/src/components/popconfirm.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   ComponentPropsWithoutRef,
   ElementRef,

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -19,31 +19,32 @@ import { getRemainingComponents } from "../helpers/getRemainingComponents";
 
 import { Typography } from "./typography";
 
-const Overlay = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<ComponentPropsWithRef<"div">>
->(({ className, ...props }, ref) => {
-  return (
-    <Transition
-      show
-      enter="duration-300 ease-out"
-      enter-from="opacity-0"
-      enter-to="opacity-100"
-      leave="duration-200 ease-in"
-      leave-from="opacity-100"
-      leave-to="opacity-0"
-    >
-      <div
-        ref={ref}
-        className={twMerge(
-          classNames("w-screen h-screen bg-overlay-3 inset-0 fixed animate-in"),
-          className
-        )}
-        {...props}
-      />
-    </Transition>
-  );
-});
+const Overlay = forwardRef<HTMLDivElement, ComponentPropsWithRef<"div">>(
+  ({ className, ...props }, ref) => {
+    return (
+      <Transition
+        show
+        enter="duration-300 ease-out"
+        enter-from="opacity-0"
+        enter-to="opacity-100"
+        leave="duration-200 ease-in"
+        leave-from="opacity-100"
+        leave-to="opacity-0"
+      >
+        <div
+          ref={ref}
+          className={twMerge(
+            classNames(
+              "w-screen h-screen bg-overlay-3 inset-0 fixed animate-in"
+            ),
+            className
+          )}
+          {...props}
+        />
+      </Transition>
+    );
+  }
+);
 Overlay.displayName = "Overlay";
 
 const Icon = forwardRef<SVGSVGElement, ComponentPropsWithoutRef<"svg">>(

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -5,6 +5,7 @@ import {
   Fragment,
   PropsWithChildren,
   forwardRef,
+  ElementRef,
 } from "react";
 import { twMerge } from "tailwind-merge";
 import classNames from "classnames";
@@ -43,12 +44,11 @@ const Overlay = forwardRef<
 });
 Overlay.displayName = "Overlay";
 
-const Icon = forwardRef<
-  SVGSVGElement,
-  PropsWithChildren<ComponentPropsWithoutRef<"svg">>
->(({ className, children, ...props }, ref) => {
-  return (
-    children ?? (
+const Icon = forwardRef<SVGSVGElement, ComponentPropsWithoutRef<"svg">>(
+  ({ className, children, ...props }, ref) => {
+    return children ? (
+      <Fragment>{children} </Fragment>
+    ) : (
       <ChevronDownIcon
         ref={ref}
         className={twMerge(
@@ -57,14 +57,14 @@ const Icon = forwardRef<
         )}
         {...props}
       />
-    )
-  );
-});
+    );
+  }
+);
 Icon.displayName = "Icon";
 
 const Close = forwardRef<
-  HTMLButtonElement,
-  PropsWithChildren<PopoverRadix.PopoverCloseProps>
+  ElementRef<typeof PopoverRadix.Close>,
+  ComponentPropsWithoutRef<typeof PopoverRadix.Close>
 >(({ children, ...props }, ref) => {
   return (
     <PopoverRadix.Close ref={ref} {...props}>
@@ -75,12 +75,15 @@ const Close = forwardRef<
 Close.displayName = "Close";
 
 export interface PopoverTriggerProps
-  extends PropsWithChildren<PopoverRadix.PopoverTriggerProps> {
+  extends ComponentPropsWithoutRef<typeof PopoverRadix.Trigger> {
   superpositionTrigger?: boolean;
   iconRotationAnimation?: boolean;
 }
 
-const Trigger = forwardRef<HTMLButtonElement, PopoverTriggerProps>(
+const Trigger = forwardRef<
+  ElementRef<typeof PopoverRadix.Trigger>,
+  PopoverTriggerProps
+>(
   (
     {
       children,
@@ -136,41 +139,42 @@ const Trigger = forwardRef<HTMLButtonElement, PopoverTriggerProps>(
 Trigger.displayName = "Trigger";
 
 export interface PopoverContentProps
-  extends PropsWithChildren<PopoverRadix.PopoverContentProps> {
+  extends ComponentPropsWithoutRef<typeof PopoverRadix.Content> {
   withArrow?: boolean;
   arrowProps?: PopoverRadix.PopoverArrowProps;
 }
 
-const Content = forwardRef<HTMLDivElement, PopoverContentProps>(
-  ({ children, className, withArrow = false, arrowProps, ...props }, ref) => {
-    const { className: arrowClassname, ...restProps } = arrowProps || {};
+const Content = forwardRef<
+  ElementRef<typeof PopoverRadix.Content>,
+  PopoverContentProps
+>(({ children, className, withArrow = false, arrowProps, ...props }, ref) => {
+  const { className: arrowClassname, ...restProps } = arrowProps || {};
 
-    return (
-      <PopoverRadix.Content
-        ref={ref}
-        className={twMerge(
-          classNames(
-            "z-50 shadow-md bg-level-1 rounded-md border border-primary min-w-[8rem]",
-            "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-            "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95"
-          ),
-          className
+  return (
+    <PopoverRadix.Content
+      ref={ref}
+      className={twMerge(
+        classNames(
+          "z-50 shadow-md bg-level-1 rounded-md border border-primary min-w-[8rem]",
+          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95"
+        ),
+        className
+      )}
+      {...props}
+    >
+      <Fragment>
+        {children}
+        {withArrow && (
+          <PopoverRadix.Arrow
+            className={twMerge(classNames("fill-level-1"), arrowClassname)}
+            {...restProps}
+          />
         )}
-        {...props}
-      >
-        <Fragment>
-          {children}
-          {withArrow && (
-            <PopoverRadix.Arrow
-              className={twMerge(classNames("fill-level-1"), arrowClassname)}
-              {...restProps}
-            />
-          )}
-        </Fragment>
-      </PopoverRadix.Content>
-    );
-  }
-);
+      </Fragment>
+    </PopoverRadix.Content>
+  );
+});
 Content.displayName = "Content";
 
 export type PopoverProps = PropsWithChildren<PopoverRadix.PopoverProps>;

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as PopoverRadix from "@radix-ui/react-popover";
 import {
   ComponentPropsWithRef,

--- a/packages/ui/src/components/processing.tsx
+++ b/packages/ui/src/components/processing.tsx
@@ -16,11 +16,7 @@ const Trigger = ({ children }: { children: ReactNode }) => {
   return <Slot>{children}</Slot>;
 };
 
-const Content = ({
-  children,
-  className,
-  ...props
-}: PropsWithChildren<ComponentProps<"div">>) => {
+const Content = ({ children, className, ...props }: ComponentProps<"div">) => {
   return (
     <div
       className={twMerge(

--- a/packages/ui/src/components/processing.tsx
+++ b/packages/ui/src/components/processing.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { Transition } from "@headlessui/react";
 import { PropsWithChildren, ComponentProps, ReactNode } from "react";
 import classNames from "classnames";

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import * as SeparatorRadix from "@radix-ui/react-separator";
 import classNames from "classnames";
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
 import { twMerge } from "tailwind-merge";
 
 import { themeConfig } from "../../../../themeConfig";
@@ -11,31 +14,30 @@ const Horizontal = (props: Omit<SeparatorProps, "orientation">) => {
 const Vertical = (props: Omit<SeparatorProps, "orientation">) => {
   return <Base orientation="vertical" {...props} />;
 };
-interface SeparatorProps extends SeparatorRadix.SeparatorProps {
+interface SeparatorProps
+  extends ComponentPropsWithoutRef<typeof SeparatorRadix.Root> {
   appearance?: keyof typeof themeConfig.theme.extend.backgroundColor;
 }
 
-const Base = ({
-  orientation,
-  className,
-  appearance = "level-3",
-  ...props
-}: SeparatorProps) => {
-  const bgColor = `bg-${appearance}`;
-  return (
-    <SeparatorRadix.Root
-      className={twMerge(
-        classNames(
-          bgColor,
-          orientation === "horizontal" ? "h-px w-full" : "w-px h-full"
-        ),
-        className
-      )}
-      {...props}
-    />
-  );
-};
-
+const Base = forwardRef<ElementRef<typeof SeparatorRadix.Root>, SeparatorProps>(
+  ({ orientation, className, appearance = "level-3", ...props }, ref) => {
+    const bgColor = `bg-${appearance}`;
+    return (
+      <SeparatorRadix.Root
+        ref={ref}
+        className={twMerge(
+          classNames(
+            bgColor,
+            orientation === "horizontal" ? "h-px w-full" : "w-px h-full"
+          ),
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Base.displayName = "Base";
 export const Separator = {
   Horizontal,
   Vertical,

--- a/packages/ui/src/components/skeleton.tsx
+++ b/packages/ui/src/components/skeleton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import classNames from "classnames";
 import { ComponentProps, Fragment, PropsWithChildren } from "react";
 import { twMerge } from "tailwind-merge";

--- a/packages/ui/src/components/spinner.tsx
+++ b/packages/ui/src/components/spinner.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ComponentProps } from "react";
 
 const Keyboard = (props: ComponentProps<"svg">) => {

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { PropsWithChildren } from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -1,20 +1,18 @@
 "use client";
 
-import { PropsWithChildren } from "react";
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
 import * as SwitchRadix from "@radix-ui/react-switch";
 
-export const Switch = ({
-  children,
-  id,
-  className,
-  disabled,
-  ...props
-}: PropsWithChildren<SwitchRadix.SwitchProps>) => {
+export const Switch = forwardRef<
+  ElementRef<typeof SwitchRadix.Root>,
+  ComponentPropsWithoutRef<typeof SwitchRadix.Root>
+>(({ children, id, className, disabled, ...props }, ref) => {
   return (
     <div className="flex items-center gap-2 group">
       <SwitchRadix.Root
+        ref={ref}
         disabled={disabled}
         className={twMerge(
           classNames(
@@ -43,4 +41,5 @@ export const Switch = ({
       )}
     </div>
   );
-};
+});
+Switch.displayName = "Switch";

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -19,7 +19,7 @@ const Caption = ({
   children,
   className,
   ...props
-}: PropsWithChildren<ComponentProps<"caption">>) => {
+}: ComponentProps<"caption">) => {
   return (
     <caption
       className={twMerge(
@@ -145,11 +145,7 @@ const Head = ({
   );
 };
 
-const Row = ({
-  children,
-  className,
-  ...props
-}: PropsWithChildren<ComponentProps<"tr">>) => {
+const Row = ({ children, className, ...props }: ComponentProps<"tr">) => {
   return (
     <tr
       className={twMerge(
@@ -165,24 +161,15 @@ const Row = ({
   );
 };
 
-const Body = ({
-  children,
-  ...props
-}: PropsWithChildren<ComponentProps<"tbody">>) => {
+const Body = ({ children, ...props }: ComponentProps<"tbody">) => {
   return <tbody {...props}>{children}</tbody>;
 };
 
-const Header = ({
-  children,
-  ...props
-}: PropsWithChildren<ComponentProps<"thead">>) => {
+const Header = ({ children, ...props }: ComponentProps<"thead">) => {
   return <thead {...props}>{children}</thead>;
 };
 
-const Footer = ({
-  children,
-  ...props
-}: PropsWithChildren<ComponentProps<"tfoot">>) => {
+const Footer = ({ children, ...props }: ComponentProps<"tfoot">) => {
   return <tfoot {...props}>{children}</tfoot>;
 };
 

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -78,17 +78,17 @@ const Icon = ({
   className,
   children,
   ...props
-}: PropsWithChildren<ComponentPropsWithoutRef<"svg">>) => {
-  return (
-    children ?? (
-      <ChevronUpDownIcon
-        className={twMerge(
-          classNames("w-3 h-3 text-primary inline-block align-middle ml-1"),
-          className
-        )}
-        {...props}
-      />
-    )
+}: ComponentPropsWithoutRef<"svg">) => {
+  return children ? (
+    <Fragment>{children} </Fragment>
+  ) : (
+    <ChevronUpDownIcon
+      className={twMerge(
+        classNames("w-3 h-3 text-primary inline-block align-middle ml-1"),
+        className
+      )}
+      {...props}
+    />
   );
 };
 

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -1,17 +1,22 @@
 "use client";
 
 import * as TabsRadix from "@radix-ui/react-tabs";
-import { PropsWithChildren } from "react";
+import {
+  ComponentPropsWithoutRef,
+  ElementRef,
+  forwardRef,
+  PropsWithChildren,
+} from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
 
-const Trigger = ({
-  children,
-  className,
-  ...props
-}: PropsWithChildren<TabsRadix.TabsTriggerProps>) => {
+const Trigger = forwardRef<
+  ElementRef<typeof TabsRadix.Trigger>,
+  ComponentPropsWithoutRef<typeof TabsRadix.Trigger>
+>(({ children, className, ...props }, ref) => {
   return (
     <TabsRadix.Trigger
+      ref={ref}
       className={twMerge(
         classNames(
           "data-[state=active]:text-primary-base hover:text-secondary text-primary data-[disabled]:text-secondary data-[disabled]:cursor-not-allowed",
@@ -24,15 +29,16 @@ const Trigger = ({
       {children}
     </TabsRadix.Trigger>
   );
-};
+});
+Trigger.displayName = "Trigger";
 
-const Content = ({
-  children,
-  className,
-  ...props
-}: PropsWithChildren<TabsRadix.TabsContentProps>) => {
+const Content = forwardRef<
+  ElementRef<typeof TabsRadix.Content>,
+  ComponentPropsWithoutRef<typeof TabsRadix.Content>
+>(({ children, className, ...props }, ref) => {
   return (
     <TabsRadix.Content
+      ref={ref}
       className={twMerge(
         classNames("flex-1 h-full data-[state=inactive]:hidden", className)
       )}
@@ -41,15 +47,16 @@ const Content = ({
       {children}
     </TabsRadix.Content>
   );
-};
+});
+Content.displayName = "Content";
 
-const List = ({
-  children,
-  className,
-  ...props
-}: PropsWithChildren<TabsRadix.TabsListProps>) => {
+const List = forwardRef<
+  ElementRef<typeof TabsRadix.List>,
+  ComponentPropsWithoutRef<typeof TabsRadix.List>
+>(({ children, className, ...props }, ref) => {
   return (
     <TabsRadix.List
+      ref={ref}
       className={twMerge(
         classNames("flex items-center flex-shrink-0 gap-3", className)
       )}
@@ -58,7 +65,8 @@ const List = ({
       {children}
     </TabsRadix.List>
   );
-};
+});
+List.displayName = "List";
 
 const Tabs = ({
   children,

--- a/packages/ui/src/components/token.tsx
+++ b/packages/ui/src/components/token.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ComponentProps } from "react";
 import { twMerge } from "tailwind-merge";
 import classNames from "classnames";

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,27 +1,36 @@
 "use client";
 
 import * as TooltipRadix from "@radix-ui/react-tooltip";
-import { PropsWithChildren } from "react";
+import {
+  ComponentPropsWithoutRef,
+  ElementRef,
+  forwardRef,
+  PropsWithChildren,
+} from "react";
 import { twMerge } from "tailwind-merge";
 import classNames from "classnames";
 
 import { isValidComponent } from "../helpers";
 
-const Trigger = ({
-  children,
-  ...props
-}: PropsWithChildren<TooltipRadix.TooltipTriggerProps>) => {
-  return <TooltipRadix.Trigger {...props}>{children}</TooltipRadix.Trigger>;
-};
+const Trigger = forwardRef<
+  ElementRef<typeof TooltipRadix.Trigger>,
+  ComponentPropsWithoutRef<typeof TooltipRadix.Trigger>
+>(({ children, ...props }, ref) => {
+  return (
+    <TooltipRadix.Trigger ref={ref} {...props}>
+      {children}
+    </TooltipRadix.Trigger>
+  );
+});
+Trigger.displayName = "Trigger";
 
-const Content = ({
-  children,
-  className,
-  sideOffset = 12,
-  ...props
-}: PropsWithChildren<TooltipRadix.TooltipContentProps>) => {
+const Content = forwardRef<
+  ElementRef<typeof TooltipRadix.Content>,
+  ComponentPropsWithoutRef<typeof TooltipRadix.Content>
+>(({ children, className, sideOffset = 12, ...props }, ref) => {
   return (
     <TooltipRadix.Content
+      ref={ref}
       sideOffset={sideOffset}
       className={twMerge(
         classNames(
@@ -37,7 +46,8 @@ const Content = ({
       {children}
     </TooltipRadix.Content>
   );
-};
+});
+Content.displayName = "Content";
 
 const Tooltip = ({
   children,

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as TooltipRadix from "@radix-ui/react-tooltip";
 import { PropsWithChildren } from "react";
 import { twMerge } from "tailwind-merge";

--- a/packages/ui/src/components/typography.tsx
+++ b/packages/ui/src/components/typography.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Children,
   ComponentProps,


### PR DESCRIPTION
## Description

#### TypeScript Errors:
Addressed TypeScript errors that were previously unnoticed during the build process. These errors are primarily related to the use of children without a Fragment.
- [x] Dropdown
- [x] Popover  
- [x] Input  
- [x] Accordion

#### Forward Refs for Component Functionality:
Implemented forward refs for specific components to ensure proper functionality.
- [x] Tooltip
- [x] HoverCard 
- [x] Tabs
- [x] Switch 
- [x] Separator 
- [x] Checkbox 


#### Elimination of Duplicate Children:
Resolved the presence of duplicate children in certain components caused by the combined use of PropsWithChildren and ComponentProps.
- [x] Drawer
- [x] Modal  
- [x] Pagination  
- [x] Popover
- [x] Processing
- [x] Table

#### Enhanced Next.js Support:
Adopted the "use client" tag for better support within the Next.js framework.
- [x] All Ui components

Close: https://github.com/Polkadex-Substrate/polkadex-ts/issues/102