### PR TITLE
Resizable component

### DIFF
--- a/.changeset/mighty-baboons-lie.md
+++ b/.changeset/mighty-baboons-lie.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/ux": minor
+---
+
+feat: resizable component

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,6 +52,7 @@
     "@radix-ui/react-toggle-group": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.7",
     "cmdk": "^0.2.1",
+    "react-resizable-panels": "^2.0.9",
     "react-use": "^17.4.0",
     "sonner": "^1.4.0",
     "tailwindcss": "^3.3.5",

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -32,3 +32,4 @@ export * from "./processing";
 export * from "./searchable";
 export * from "./toggleGroup";
 export * from "./filterGroup";
+export * from "./resizable";

--- a/packages/ui/src/components/resizable.tsx
+++ b/packages/ui/src/components/resizable.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import * as ResizablePanels from "react-resizable-panels";
+import { ComponentProps } from "react";
+import classNames from "classnames";
+import { twMerge } from "tailwind-merge";
+import { Bars2Icon } from "@heroicons/react/24/solid";
+
+const Resizable = ({
+  children,
+  className,
+  ...props
+}: ComponentProps<typeof ResizablePanels.PanelGroup>) => {
+  return (
+    <ResizablePanels.PanelGroup
+      className={twMerge(
+        classNames(
+          "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+          className
+        )
+      )}
+      {...props}
+    >
+      {children}
+    </ResizablePanels.PanelGroup>
+  );
+};
+
+const Panel = ({
+  children,
+  ...props
+}: ComponentProps<typeof ResizablePanels.Panel>) => {
+  return <ResizablePanels.Panel {...props}>{children}</ResizablePanels.Panel>;
+};
+
+interface HandleProps
+  extends ComponentProps<typeof ResizablePanels.PanelResizeHandle> {
+  withHandle?: boolean;
+}
+const Handle = ({ className, withHandle, ...props }: HandleProps) => {
+  return (
+    <ResizablePanels.PanelResizeHandle
+      className={twMerge(
+        classNames(
+          "relative flex w-px items-center justify-center bg-level-2",
+          "after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2",
+          "data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+          className
+        )
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm  bg-level-5 border border-secondary">
+          <Bars2Icon className="h-2.5 w-2.5 rotate-180" />
+        </div>
+      )}
+    </ResizablePanels.PanelResizeHandle>
+  );
+};
+
+Resizable.Handle = Handle;
+Resizable.Panel = Panel;
+export { Resizable };


### PR DESCRIPTION
## Description
This pull request introduces a solution to the challenge posed by complex layouts in certain Polkadex apps, such as Orderbook, that require scalability on smaller screens. To address this issue, we have created a reusable component named Resizable Component. This component utilizes the capabilities of react-resizable-panels to enable dynamic resizing of specific components.

## Screenshot
![Screenshot 2024-02-19 at 21 12 54](https://github.com/Polkadex-Substrate/polkadex-ts/assets/12574469/a5e1390f-5803-46c7-b408-b6d2e2c91fda)

Close: https://github.com/Polkadex-Substrate/polkadex-ts/issues/129