### PR TITLE
@polkadex/ux patch 6

### DIFF
--- a/.changeset/shy-vans-kick.md
+++ b/.changeset/shy-vans-kick.md
@@ -1,0 +1,9 @@
+---
+"@polkadex/ux": minor
+---
+
+- [x] fix: Resizable Component ForwardRef Implementation
+- [x] fix: Icon Library Upgrade - Heroicons to Remixicons:
+- [x] fix: Overlay Z-Index Adjustment for Dropdown, Popover, and Modal
+- [x] fix: Remove Fill from Three Icons - Ask, Bid, and AskAndBid
+- [x] fix: New Input Component Prop - containerProps

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.4",
     "@headlessui/react": "^1.7.18",
-    "@heroicons/react": "^2.0.18",
+    "@remixicon/react": "^4.2.0",
     "@polkadex/react-providers": "*",
     "@polkadot-cloud/assets": "^0.1.35",
     "@radix-ui/react-accordion": "^1.1.2",

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -7,9 +7,9 @@ import {
   ElementRef,
 } from "react";
 import * as AccordionRadix from "@radix-ui/react-accordion";
-import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import { twMerge } from "tailwind-merge";
 import classNames from "classnames";
+import { RiArrowDownSLine } from "@remixicon/react";
 
 import {
   isValidComponent,
@@ -25,7 +25,7 @@ const Icon = forwardRef<SVGSVGElement, ComponentPropsWithoutRef<"svg">>(
     return children ? (
       <Fragment>{children} </Fragment>
     ) : (
-      <ChevronDownIcon
+      <RiArrowDownSLine
         ref={ref}
         className={twMerge(
           classNames(

--- a/packages/ui/src/components/copy.tsx
+++ b/packages/ui/src/components/copy.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { ComponentProps, MouseEvent, PropsWithChildren, useState } from "react";
-import { DocumentDuplicateIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
 import { TooltipContentProps } from "@radix-ui/react-tooltip";
 import { twMerge } from "tailwind-merge";
+import { RiFileCopyLine } from "@remixicon/react";
 
 import { Tooltip } from "./tooltip";
 
@@ -40,7 +40,7 @@ export const Copy = ({
     <Tooltip onOpenChange={setOpen} open={open}>
       <Tooltip.Trigger onClick={onCopy} onMouseOut={onMouseOut}>
         {children ?? (
-          <DocumentDuplicateIcon
+          <RiFileCopyLine
             className={twMerge(classNames("w-3 h-3 text-secondary"), className)}
           />
         )}

--- a/packages/ui/src/components/drawer.tsx
+++ b/packages/ui/src/components/drawer.tsx
@@ -84,7 +84,7 @@ const Drawer = ({
       <DrawerVaul.Portal container={containerRef.current}>
         <DrawerVaul.Overlay
           className={classNames(
-            " bg-overlay-2 inset-0 fixed data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "z-[15] bg-overlay-2 inset-0 fixed data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
             blured && "backdrop-blur-primary "
           )}
           onClick={

--- a/packages/ui/src/components/dropdown.tsx
+++ b/packages/ui/src/components/dropdown.tsx
@@ -39,7 +39,7 @@ const Overlay = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<"div">>(
           ref={ref}
           className={twMerge(
             classNames(
-              "w-screen h-screen bg-overlay-3 inset-0 fixed animate-in"
+              "w-screen h-screen bg-overlay-3 inset-0 fixed animate-in z-[10]"
             ),
             className
           )}

--- a/packages/ui/src/components/dropdown.tsx
+++ b/packages/ui/src/components/dropdown.tsx
@@ -9,11 +9,10 @@ import {
   forwardRef,
   ElementRef,
 } from "react";
-import { CheckIcon } from "@heroicons/react/24/outline";
 import { twMerge } from "tailwind-merge";
 import classNames from "classnames";
-import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import { Transition } from "@headlessui/react";
+import { RiArrowDownSLine, RiCheckLine } from "@remixicon/react";
 
 import {
   isValidComponent,
@@ -57,7 +56,7 @@ const Icon = forwardRef<SVGSVGElement, ComponentPropsWithoutRef<"svg">>(
     return children ? (
       <Fragment>{children} </Fragment>
     ) : (
-      <ChevronDownIcon
+      <RiArrowDownSLine
         ref={ref}
         className={twMerge(
           classNames("h-4 w-4 transition-transform duration-300 text-primary"),
@@ -140,7 +139,7 @@ const ItemCheckbox = forwardRef<
       {...props}
     >
       <DropdownMenu.ItemIndicator>
-        <CheckIcon className="w-3 h-3 text-primary-base [&_path]:stroke-[3px]" />
+        <RiCheckLine className="w-3 h-3 text-primary-base [&_path]:stroke-[3px]" />
       </DropdownMenu.ItemIndicator>
       {(isString && <Typography.Text>{children}</Typography.Text>) || children}
     </DropdownMenu.CheckboxItem>

--- a/packages/ui/src/components/dropdown.tsx
+++ b/packages/ui/src/components/dropdown.tsx
@@ -39,7 +39,7 @@ const Overlay = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<"div">>(
           ref={ref}
           className={twMerge(
             classNames(
-              "w-screen h-screen bg-overlay-3 inset-0 fixed animate-in z-[10]"
+              "w-screen h-screen bg-overlay-3 inset-0 fixed animate-in z-[15]"
             ),
             className
           )}

--- a/packages/ui/src/components/filterGroup.tsx
+++ b/packages/ui/src/components/filterGroup.tsx
@@ -8,9 +8,9 @@ import {
   Fragment,
   PropsWithChildren,
 } from "react";
-import { PlusCircleIcon } from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
+import { RiAddLine } from "@remixicon/react";
 
 import {
   getChildren,
@@ -31,7 +31,7 @@ const Icon = forwardRef<SVGSVGElement, ComponentPropsWithoutRef<"svg">>(
     return children ? (
       <Fragment>{children} </Fragment>
     ) : (
-      <PlusCircleIcon
+      <RiAddLine
         ref={ref}
         className={twMerge(
           classNames("h-5 w-5 transition-transform duration-300 text-white"),

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -1,11 +1,6 @@
 "use client";
 
 import {
-  MagnifyingGlassIcon,
-  MinusIcon,
-  PlusIcon,
-} from "@heroicons/react/24/solid";
-import {
   ChangeEvent,
   ComponentProps,
   ComponentPropsWithoutRef,
@@ -23,6 +18,7 @@ import {
 } from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
+import { RiAddLine, RiSearchLine, RiSubtractLine } from "@remixicon/react";
 
 import { isValidComponent } from "../helpers";
 
@@ -119,9 +115,9 @@ const Button = ({
       {...props}
     >
       {variant === "increase" ? (
-        <PlusIcon className="w-3 h-3" />
+        <RiAddLine className="w-3 h-3" />
       ) : (
-        <MinusIcon className="w-3 h-3" />
+        <RiSubtractLine className="w-3 h-3" />
       )}
     </button>
   );
@@ -151,7 +147,7 @@ const Search = forwardRef<
 >((props, ref) => {
   return (
     <div className="flex flex-1 items-center gap-2">
-      <MagnifyingGlassIcon className="w-4 h-4 text-primary" />
+      <RiSearchLine className="w-4 h-4 text-primary" />
       <Base ref={ref} className="text-sm" {...props} />
     </div>
   );

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -64,37 +64,44 @@ const Base = forwardRef<ElementRef<"input">, ComponentPropsWithoutRef<"input">>(
 
 Base.displayName = "Base";
 
-const Primary = forwardRef<
-  ElementRef<"input">,
-  ComponentPropsWithoutRef<"input">
->(({ children, ...props }) => {
-  const ref = useRef<HTMLInputElement>(null);
-  const ButtonComponents = isValidComponent(children, Button);
-  const [LabelComponent] = isValidComponent(children, Label);
-  const [TickerComponent] = isValidComponent(children, Ticker);
+interface InputWithContainerProps extends ComponentPropsWithoutRef<"input"> {
+  contianerProps?: ComponentProps<"div">;
+}
+const Primary = forwardRef<ElementRef<"input">, InputWithContainerProps>(
+  ({ children, contianerProps, ...props }) => {
+    const ref = useRef<HTMLInputElement>(null);
+    const ButtonComponents = isValidComponent(children, Button);
+    const [LabelComponent] = isValidComponent(children, Label);
+    const [TickerComponent] = isValidComponent(children, Ticker);
 
-  return (
-    <div
-      className="flex justify-between items-center gap-2 bg-level-3 h-[45px] rounded"
-      onClick={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        ref?.current?.focus();
-      }}
-    >
-      <div className="flex flex-1 items-center justify-between gap-2 pl-3 pr-2">
-        <div className="flex items-center gap-2">
-          {LabelComponent}
-          <Base ref={ref} className="text-sm" {...props} />
+    const { className } = contianerProps ?? {};
+    return (
+      <div
+        className={classNames(
+          "flex justify-between items-center gap-2 bg-level-3 h-[45px] rounded",
+          className
+        )}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          ref?.current?.focus();
+        }}
+        {...contianerProps}
+      >
+        <div className="flex flex-1 items-center justify-between gap-2 pl-3 pr-2">
+          <div className="flex items-center gap-2">
+            {LabelComponent}
+            <Base ref={ref} className="text-sm" {...props} />
+          </div>
+          {TickerComponent}
         </div>
-        {TickerComponent}
+        {!!ButtonComponents?.length && (
+          <div className="flex h-full flex-col gap-0.5">{ButtonComponents}</div>
+        )}
       </div>
-      {!!ButtonComponents?.length && (
-        <div className="flex h-full flex-col gap-0.5">{ButtonComponents}</div>
-      )}
-    </div>
-  );
-});
+    );
+  }
+);
 
 Primary.displayName = "Primary";
 
@@ -141,29 +148,31 @@ const Label = ({
   <LabelPolkadex appearance={appearance} size={size} {...props} />
 );
 
-const Search = forwardRef<
-  ElementRef<"input">,
-  ComponentPropsWithoutRef<"input">
->((props, ref) => {
-  return (
-    <div className="flex flex-1 items-center gap-2">
-      <RiSearchLine className="w-4 h-4 text-primary" />
-      <Base ref={ref} className="text-sm" {...props} />
-    </div>
-  );
-});
+const Search = forwardRef<ElementRef<"input">, InputWithContainerProps>(
+  ({ contianerProps, ...props }, ref) => {
+    const { className } = contianerProps ?? {};
+    return (
+      <div className={classNames("flex flex-1 items-center gap-2", className)}>
+        <RiSearchLine className="w-4 h-4 text-primary" />
+        <Base ref={ref} className="text-sm" {...props} />
+      </div>
+    );
+  }
+);
 Search.displayName = "Search";
 
 const Vertical = ({
   id,
   children,
+  contianerProps,
   ...props
-}: ComponentPropsWithoutRef<"input">) => {
+}: InputWithContainerProps) => {
   const LabelComponent = isValidComponent(children, Label);
   const ButtonComponent = isValidComponent(children, Action);
 
+  const { className } = contianerProps ?? {};
   return (
-    <div className="flex flex-col gap-2 w-full">
+    <div className={classNames("flex flex-col gap-2 w-full", className)}>
       {LabelComponent}
       <div className="flex items-center justify-between gap-2 flex-1">
         <Base id={id} className="text-lg font-medium" {...props} />

--- a/packages/ui/src/components/interaction.tsx
+++ b/packages/ui/src/components/interaction.tsx
@@ -7,9 +7,9 @@ import {
   PropsWithoutRef,
 } from "react";
 import classNames from "classnames";
-import { ArrowLeftIcon, XMarkIcon } from "@heroicons/react/24/solid";
 import { twMerge } from "tailwind-merge";
 import { Transition } from "@headlessui/react";
+import { RiArrowLeftLine, RiCloseLine } from "@remixicon/react";
 
 import { isValidComponent, typeofChildren } from "../helpers";
 
@@ -49,7 +49,7 @@ const Title = ({
     >
       {hasBack && (
         <Button.Icon onClick={onBack} variant="ghost" rounded>
-          <ArrowLeftIcon className="text-secondary group-hover:text-white" />
+          <RiArrowLeftLine className="w-full h-full text-secondary group-hover:text-white" />
         </Button.Icon>
       )}
       {isString ? (
@@ -62,7 +62,7 @@ const Title = ({
 
       {hasClose && (
         <Button.Icon onClick={onClose} variant="ghost" rounded>
-          <XMarkIcon className="text-secondary group-hover:text-white" />
+          <RiCloseLine className="w-full h-full text-secondary group-hover:text-white" />
         </Button.Icon>
       )}
     </div>

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -81,7 +81,7 @@ const Modal = ({
       <AlertDialog.Portal container={containerRef.current}>
         <AlertDialog.Overlay
           className={classNames(
-            "backdrop-blur-primary inset-0 fixed z-[10]",
+            "backdrop-blur-primary inset-0 fixed z-[15]",
             "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
           )}
           onClick={

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -81,7 +81,7 @@ const Modal = ({
       <AlertDialog.Portal container={containerRef.current}>
         <AlertDialog.Overlay
           className={classNames(
-            "backdrop-blur-primary inset-0 fixed",
+            "backdrop-blur-primary inset-0 fixed z-[10]",
             "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
           )}
           onClick={

--- a/packages/ui/src/components/pagination.tsx
+++ b/packages/ui/src/components/pagination.tsx
@@ -3,7 +3,7 @@
 import classNames from "classnames";
 import { ComponentProps, PropsWithChildren, PropsWithoutRef } from "react";
 import { twMerge } from "tailwind-merge";
-import * as Icons from "@heroicons/react/24/solid";
+import * as Icons from "@remixicon/react";
 
 import {
   Button as PolkadexButton,
@@ -28,16 +28,10 @@ const Page = ({
   );
 };
 
-const Ellipsis = ({
-  className,
-  ...props
-}: PropsWithChildren<Omit<ComponentProps<"svg">, "ref">>) => {
+const Ellipsis = ({ className }: ComponentProps<"svg">) => {
   return (
     <div>
-      <Icons.EllipsisHorizontalIcon
-        className={classNames("w-4 h-4", className)}
-        {...props}
-      />
+      <Icons.RiMore2Line className={classNames("w-4 h-4", className)} />
     </div>
   );
 };
@@ -91,7 +85,9 @@ const Button = ({
   ...props
 }: PropsWithoutRef<ButtonProps>) => {
   const IconComponent =
-    Icons[arrowType === "single" ? "ChevronLeftIcon" : "ChevronDoubleLeftIcon"];
+    Icons[
+      arrowType === "single" ? "RiArrowLeftSLine" : "RiArrowLeftDoubleLine"
+    ];
 
   return (
     <>

--- a/packages/ui/src/components/popconfirm.tsx
+++ b/packages/ui/src/components/popconfirm.tsx
@@ -8,9 +8,9 @@ import {
   PropsWithChildren,
   PropsWithoutRef,
 } from "react";
-import { InformationCircleIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
+import { RiInformationLine } from "@remixicon/react";
 
 import {
   isValidComponent,
@@ -119,7 +119,7 @@ const Content = forwardRef<ElementRef<typeof Popover.Content>, ContentProps>(
         {...props}
       >
         {withIcon && (
-          <InformationCircleIcon className="w-4 h-4 mt-1 text-attention-base" />
+          <RiInformationLine className="w-4 h-4 mt-1 text-attention-base" />
         )}
         <div className="flex flex-col gap-4">
           <div className="flex flex-col">

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -35,7 +35,7 @@ const Overlay = forwardRef<HTMLDivElement, ComponentPropsWithRef<"div">>(
           ref={ref}
           className={twMerge(
             classNames(
-              "w-screen h-screen bg-overlay-3 inset-0 fixed animate-in z-[10]"
+              "w-screen h-screen bg-overlay-3 inset-0 fixed animate-in z-[15]"
             ),
             className
           )}

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -11,8 +11,8 @@ import {
 } from "react";
 import { twMerge } from "tailwind-merge";
 import classNames from "classnames";
-import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import { Transition } from "@headlessui/react";
+import { RiArrowDownSLine } from "@remixicon/react";
 
 import { isValidComponentWithoutTarget, typeofChildren } from "../helpers";
 import { getRemainingComponents } from "../helpers/getRemainingComponents";
@@ -52,7 +52,7 @@ const Icon = forwardRef<SVGSVGElement, ComponentPropsWithoutRef<"svg">>(
     return children ? (
       <Fragment>{children} </Fragment>
     ) : (
-      <ChevronDownIcon
+      <RiArrowDownSLine
         ref={ref}
         className={twMerge(
           classNames("h-4 w-4 transition-transform duration-300 text-primary"),

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -35,7 +35,7 @@ const Overlay = forwardRef<HTMLDivElement, ComponentPropsWithRef<"div">>(
           ref={ref}
           className={twMerge(
             classNames(
-              "w-screen h-screen bg-overlay-3 inset-0 fixed animate-in"
+              "w-screen h-screen bg-overlay-3 inset-0 fixed animate-in z-[10]"
             ),
             className
           )}

--- a/packages/ui/src/components/resizable.tsx
+++ b/packages/ui/src/components/resizable.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import * as ResizablePanels from "react-resizable-panels";
-import { ComponentProps } from "react";
+import { ComponentProps, forwardRef } from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
-import { Bars2Icon } from "@heroicons/react/24/solid";
+import { RiDraggable } from "@remixicon/react";
+import type { ImperativePanelHandle } from "react-resizable-panels";
 
 const Resizable = ({
   children,
@@ -26,12 +27,17 @@ const Resizable = ({
   );
 };
 
-const Panel = ({
-  children,
-  ...props
-}: ComponentProps<typeof ResizablePanels.Panel>) => {
-  return <ResizablePanels.Panel {...props}>{children}</ResizablePanels.Panel>;
-};
+const Panel = forwardRef<
+  ImperativePanelHandle,
+  ComponentProps<typeof ResizablePanels.Panel>
+>(({ children, ...props }, ref) => {
+  return (
+    <ResizablePanels.Panel ref={ref} {...props}>
+      {children}
+    </ResizablePanels.Panel>
+  );
+});
+Panel.displayName = "Panel";
 
 interface HandleProps
   extends ComponentProps<typeof ResizablePanels.PanelResizeHandle> {
@@ -52,7 +58,7 @@ const Handle = ({ className, withHandle, ...props }: HandleProps) => {
     >
       {withHandle && (
         <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm  bg-level-5 border border-secondary">
-          <Bars2Icon className="h-2.5 w-2.5 rotate-180" />
+          <RiDraggable className="h-2.5 w-2.5 rotate-180" />
         </div>
       )}
     </ResizablePanels.PanelResizeHandle>
@@ -61,4 +67,4 @@ const Handle = ({ className, withHandle, ...props }: HandleProps) => {
 
 Resizable.Handle = Handle;
 Resizable.Panel = Panel;
-export { Resizable };
+export { Resizable, ImperativePanelHandle };

--- a/packages/ui/src/components/searchable.tsx
+++ b/packages/ui/src/components/searchable.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { MagnifyingGlassIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
 import { Command } from "cmdk";
 import {
@@ -10,6 +9,7 @@ import {
   forwardRef,
 } from "react";
 import { twMerge } from "tailwind-merge";
+import { RiSearchLine } from "@remixicon/react";
 
 import { NoResultFound } from "../illustrations";
 
@@ -58,7 +58,7 @@ const Input = forwardRef<
       ref={ref}
       className="flex flex-1 border-b pb-2 border-primary items-center gap-2"
     >
-      <MagnifyingGlassIcon className="w-4 h-4 text-primary" />
+      <RiSearchLine className="w-4 h-4 text-primary" />
       <Command.Input
         className={twMerge(
           classNames(

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
-import { ChevronUpDownIcon } from "@heroicons/react/24/outline";
+import { RiExpandUpDownLine } from "@remixicon/react";
 
 import { isValidComponentWithoutTarget, typeofChildren } from "../helpers";
 import { getRemainingComponents } from "../helpers/getRemainingComponents";
@@ -82,7 +82,7 @@ const Icon = ({
   return children ? (
     <Fragment>{children} </Fragment>
   ) : (
-    <ChevronUpDownIcon
+    <RiExpandUpDownLine
       className={twMerge(
         classNames("w-3 h-3 text-primary inline-block align-middle ml-1"),
         className

--- a/packages/ui/src/icons/ask.tsx
+++ b/packages/ui/src/icons/ask.tsx
@@ -13,6 +13,7 @@ export function Ask(props: ComponentProps<"svg">) {
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
+        fill="none"
       />
     </svg>
   );

--- a/packages/ui/src/icons/askAndBid.tsx
+++ b/packages/ui/src/icons/askAndBid.tsx
@@ -13,6 +13,7 @@ export function AskAndBid(props: ComponentProps<"svg">) {
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
+        fill="none"
       />
       <path
         d="M2.20011 20L9.09998 20C10.6 20 11.2 19.36 11.2 17.77L11.2 13.73C11.2 12.14 10.6 11.5 9.09998 11.5L2.20012 11.5C0.700115 11.5 0.100115 12.14 0.100115 13.73L0.100115 17.77C0.100114 19.36 0.700115 20 2.20011 20Z"

--- a/packages/ui/src/icons/bid.tsx
+++ b/packages/ui/src/icons/bid.tsx
@@ -13,6 +13,7 @@ export function Bid(props: ComponentProps<"svg">) {
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
+        fill="none"
       />
     </svg>
   );

--- a/packages/ui/src/icons/download.tsx
+++ b/packages/ui/src/icons/download.tsx
@@ -9,6 +9,7 @@ export function Download(props: ComponentProps<"svg">) {
         strokeWidth="1.69995"
         strokeLinecap="round"
         strokeLinejoin="round"
+        fill="none"
       />
       <path
         d="M9.6001 18.7546L7.3335 16.488"
@@ -16,6 +17,7 @@ export function Download(props: ComponentProps<"svg">) {
         strokeWidth="1.69995"
         strokeLinecap="round"
         strokeLinejoin="round"
+        fill="none"
       />
       <path
         d="M24.333 10.8215V16.488C24.333 22.1545 22.0664 24.4211 16.3999 24.4211H9.6001C3.93359 24.4211 1.66699 22.1545 1.66699 16.488V9.68823C1.66699 4.02173 3.93359 1.75513 9.6001 1.75513H15.2666"
@@ -23,6 +25,7 @@ export function Download(props: ComponentProps<"svg">) {
         strokeWidth="1.69995"
         strokeLinecap="round"
         strokeLinejoin="round"
+        fill="none"
       />
       <path
         d="M24.333 10.8215H19.7998C16.3999 10.8215 15.2666 9.68823 15.2666 6.28833V1.75513L24.333 10.8215Z"
@@ -30,6 +33,7 @@ export function Download(props: ComponentProps<"svg">) {
         strokeWidth="1.69995"
         strokeLinecap="round"
         strokeLinejoin="round"
+        fill="none"
       />
     </svg>
   );

--- a/packages/ui/src/plugAndPlay/connectWallet/authorization.tsx
+++ b/packages/ui/src/plugAndPlay/connectWallet/authorization.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { XMarkIcon } from "@heroicons/react/24/solid";
 import { ElementType, useCallback, useEffect, useState } from "react";
 import { getExtensionIcon } from "@polkadot-cloud/assets/extensions";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
+import { RiCloseLine } from "@remixicon/react";
 
 import {
   Interaction,
@@ -67,7 +67,7 @@ export const Authorization = ({
               <div className="h-20 w-20 bg-level-2 rounded-full p-3 relative shadow-baseShadow">
                 {extensionIcon && <IconComponent />}
                 <div className="h-6 w-6 p-1 rounded-full bg-danger-base absolute bottom-0 right-0">
-                  <XMarkIcon />
+                  <RiCloseLine className="w-full h-full" />
                 </div>
               </div>
             </div>

--- a/packages/ui/src/readyToUse/transactionLoading.tsx
+++ b/packages/ui/src/readyToUse/transactionLoading.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 import { ComponentProps, ElementType, PropsWithChildren } from "react";
 import { twMerge } from "tailwind-merge";
 import { getExtensionIcon } from "@polkadot-cloud/assets/extensions";
-import { XMarkIcon } from "@heroicons/react/24/solid";
+import { RiCloseLine } from "@remixicon/react";
 
 import { Button, Spinner, Typography } from "../components";
 
@@ -44,7 +44,7 @@ export const TransactionLoading = ({
         <div className="flex flex-col gap-5 w-full">
           <div className="flex flex-col gap-5 items-center text-center">
             <div className="h-12 w-12 rounded-full bg-danger-base p-2 shadow-baseShadow">
-              <XMarkIcon />
+              <RiCloseLine className="w-full h-full" />
             </div>
             <div className="flex flex-col gap-1">
               <Typography.Text bold size="xl">


### PR DESCRIPTION
## Description:
This pull request addresses multiple issues within the @polkadex/ux package, introducing fixes and improvements.

- [x] fix: Resizable Component ForwardRef Implementation: Implemented forwardRef in the Resizable componen.
- [x] fix: Icon Library Upgrade, Heroicons to Remixicons:
- [x] fix: Overlay Z-Index Adjustment for Dropdown, Popover, and Modal:
- [x] fix: Remove Fill from Three Icons: Ask, Bid, and AskAndBid:
- [x] fix: New Input Component Prop: containerProps: