### PR TITLE
fix: logic for blocks to next epoch

### DIFF
--- a/.changeset/clean-scissors-happen.md
+++ b/.changeset/clean-scissors-happen.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/polkadex-api": patch
+---
+
+fix: logic for blocks to next epoch

--- a/packages/polkadex-api/src/modules/lmp.ts
+++ b/packages/polkadex-api/src/modules/lmp.ts
@@ -29,8 +29,8 @@ export class LmpApi extends BalancesApi {
   public async blocksToNextEpoch(): Promise<number> {
     await this.initApi();
     const currBlock = await this.getLatestBlockNumber();
-    const startBlock = Math.floor(currBlock / TIME_INTERVALS.blocksInEpoch);
-    return startBlock + TIME_INTERVALS.blocksInEpoch;
+    const blocksAfterPrevEpochStart = currBlock % TIME_INTERVALS.blocksInEpoch;
+    return TIME_INTERVALS.blocksInEpoch - blocksAfterPrevEpochStart;
   }
 
   /**

--- a/packages/polkadex-api/src/modules/lmp.ts
+++ b/packages/polkadex-api/src/modules/lmp.ts
@@ -26,11 +26,12 @@ export class LmpApi extends BalancesApi {
   /**
    * @summary get number of blocks to start of next epoch
    */
-  public async blocksToNextEpoch(): Promise<number> {
+  public async blocksToNextEpoch(blocksInEpoch?: number): Promise<number> {
     await this.initApi();
+    const BLOCKS_IN_EPOCH = blocksInEpoch || TIME_INTERVALS.blocksInEpoch;
     const currBlock = await this.getLatestBlockNumber();
-    const blocksAfterPrevEpochStart = currBlock % TIME_INTERVALS.blocksInEpoch;
-    return TIME_INTERVALS.blocksInEpoch - blocksAfterPrevEpochStart;
+    const blocksAfterPrevEpochStart = currBlock % BLOCKS_IN_EPOCH;
+    return BLOCKS_IN_EPOCH - blocksAfterPrevEpochStart;
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved the accuracy of calculating the remaining blocks until the next epoch in the Polkadex API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->