### PR TITLE
fix: handle very large numbers

### DIFF
--- a/.changeset/odd-suits-boil.md
+++ b/.changeset/odd-suits-boil.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/numericals": minor
+---
+
+Handled edge case for very large numbers

--- a/.changeset/odd-suits-boil.md
+++ b/.changeset/odd-suits-boil.md
@@ -2,4 +2,4 @@
 "@polkadex/numericals": minor
 ---
 
-Handled edge case for very large numbers
+Handled edge case for massive numbers

--- a/packages/numericals/src/index.test.ts
+++ b/packages/numericals/src/index.test.ts
@@ -133,4 +133,9 @@ describe("Utils function testing <> millify", () => {
     const res = millify(value);
     expect(res).toBe("991.39B");
   });
+  it("Should convert 78013880138038318308310 -> 78013880138.04T", () => {
+    const value = "78013880138038318308310";
+    const res = millify(value);
+    expect(res).toBe("78013880138.04T");
+  });
 });

--- a/packages/numericals/src/index.ts
+++ b/packages/numericals/src/index.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import abbreviateNumber from "millify";
+import { millify as abbreviateNumber } from "millify";
 import {
   minDecimalPlaces,
   planckToUnit,
@@ -156,9 +156,19 @@ export const millify = (
   const actualSpace = space || false;
   const actualUnits = units || ["", "K", "M", "B", "T", "P", "E"];
 
-  return abbreviateNumber(+actualValue, {
-    precision: actualPrecision,
-    space: actualSpace,
-    units: actualUnits,
-  });
+  if (+actualValue < Math.pow(2, 53)) {
+    return abbreviateNumber(+actualValue, {
+      precision: actualPrecision,
+      space: actualSpace,
+      units: actualUnits,
+    });
+  }
+
+  const TRILLION = Math.pow(10, 12);
+
+  return (
+    (+actualValue / TRILLION).toFixed(actualPrecision) +
+    (space ? " " : "") +
+    "T"
+  );
 };


### PR DESCRIPTION
In millify function, there was an missing edge case for handling very very large numbers i.e. numbers which contains around 25-40 digits.

This case is being handled now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the number formatting functionality to improve handling of very large numbers and renamed it for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->