### PR TITLE
Add polkadex assets

### DIFF
--- a/.changeset/funny-items-visit.md
+++ b/.changeset/funny-items-visit.md
@@ -1,0 +1,7 @@
+---
+"@polkadex/polkadex-api": minor
+"@polkadex/cross-chain": minor
+"@polkadex/thea": minor
+---
+
+This task is about to add the metadata of supported assets for Polkadex network and make the project build succesful (if it breaks anything)

--- a/apps/cross-chain/app/components/polkadotEco.tsx
+++ b/apps/cross-chain/app/components/polkadotEco.tsx
@@ -18,6 +18,7 @@ export const PolkadotEco = () => {
   const queryBalances = async () => {
     const srcChain = getAllChains().find((c) => c.name === SOURCE_CHAIN);
     if (!srcChain) throw new Error(`${SOURCE_CHAIN} chain not found..`);
+    console.log("Querying balances...");
     const srcChainConnector = getChainConnector(srcChain.genesis);
     const assets = srcChainConnector.getSupportedAssets();
     const balances = await srcChainConnector.getBalances(fromAddress, assets);

--- a/packages/polkadex-api/src/modules/constants.ts
+++ b/packages/polkadex-api/src/modules/constants.ts
@@ -1,3 +1,5 @@
+import { Asset, AssetType } from "../types";
+
 export const TIME_INTERVALS = {
   secondsInBlock: 12,
   blocksInDay: 7200,
@@ -5,10 +7,79 @@ export const TIME_INTERVALS = {
   blocksInEpoch: 201600,
 };
 
-export const ASSET_ID = {
-  DOT: "95930534000017180603917534864279132680",
-  USDT: "3496813586714279103986568049643838918",
-  USDC: "304494718746685751324769169435167367843",
-  DED: "119367686984583275840673742485354142551",
-  PINK: "339306133874233608313826294843504252047",
-};
+export const ASSETS: Asset[] = [
+  {
+    name: "DOT",
+    ticker: "DOT",
+    id: "95930534000017180603917534864279132680",
+    decimal: 12,
+    network: AssetType.Substrate,
+  },
+  {
+    name: "USDT",
+    ticker: "USDT",
+    id: "3496813586714279103986568049643838918",
+    decimal: 12,
+    network: AssetType.Substrate,
+  },
+  {
+    name: "USDC",
+    ticker: "USDC",
+    id: "304494718746685751324769169435167367843",
+    decimal: 12,
+    network: AssetType.Substrate,
+  },
+  {
+    name: "DED",
+    ticker: "DED",
+    id: "119367686984583275840673742485354142551",
+    decimal: 12,
+    network: AssetType.Substrate,
+  },
+  {
+    name: "PINK",
+    ticker: "PINK",
+    id: "339306133874233608313826294843504252047",
+    decimal: 12,
+    network: AssetType.Substrate,
+  },
+  {
+    name: "UNQ",
+    ticker: "UNQ",
+    id: "32595388462891559990827225517299393930",
+    decimal: 12,
+    network: AssetType.Substrate,
+  },
+  {
+    name: "GLMR",
+    ticker: "GLMR",
+    id: "182269558229932594457975666948556356791",
+    decimal: 12,
+    network: AssetType.Substrate,
+  },
+  {
+    name: "IBTC",
+    ticker: "IBTC",
+    id: "226557799181424065994173367616174607641",
+    decimal: 12,
+    network: AssetType.Substrate,
+  },
+  {
+    name: "PHA",
+    ticker: "PHA",
+    id: "193492391581201937291053139015355410612",
+    decimal: 12,
+    network: AssetType.Substrate,
+  },
+  {
+    name: "ASTR",
+    ticker: "ASTR",
+    id: "222121451965151777636299756141619631150",
+    decimal: 12,
+    network: AssetType.Substrate,
+  },
+];
+
+export const ASSETS_MAP = new Map<string, Asset>(
+  ASSETS.map((a) => [a.ticker, a])
+);

--- a/packages/polkadex-api/src/types.ts
+++ b/packages/polkadex-api/src/types.ts
@@ -1,5 +1,17 @@
 import { DefinitionsCall } from "@polkadot/types/types";
 
+export enum AssetType {
+  Substrate,
+  EVM,
+}
+export type Asset = {
+  name: string;
+  ticker: string;
+  id: string;
+  decimal: number;
+  network: AssetType;
+};
+
 export const runtimeTypes = {
   AssetId: {
     _enum: {

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -1,5 +1,5 @@
 import { Parachain, Ecosystem, AnyChain } from "@moonbeam-network/xcm-types";
-import { ASSET_ID } from "@polkadex/polkadex-api";
+import { ASSETS_MAP } from "@polkadex/polkadex-api";
 
 import {
   ASSETHUB_GENESIS,
@@ -73,28 +73,28 @@ export const polkadex = new Parachain({
     },
     {
       asset: dot,
-      decimals: 12,
-      id: ASSET_ID.DOT,
+      decimals: ASSETS_MAP.get("DOT")?.decimal,
+      id: ASSETS_MAP.get("DOT")?.id,
     },
     {
       asset: usdt,
-      decimals: 12,
-      id: ASSET_ID.USDT,
+      decimals: ASSETS_MAP.get("USDT")?.decimal,
+      id: ASSETS_MAP.get("USDT")?.id,
     },
     {
       asset: usdc,
-      decimals: 12,
-      id: ASSET_ID.USDC,
+      decimals: ASSETS_MAP.get("USDC")?.decimal,
+      id: ASSETS_MAP.get("USDC")?.id,
     },
     {
       asset: ded,
-      decimals: 12,
-      id: ASSET_ID.DED,
+      decimals: ASSETS_MAP.get("DED")?.decimal,
+      id: ASSETS_MAP.get("DED")?.id,
     },
     {
       asset: pink,
-      decimals: 12,
-      id: ASSET_ID.PINK,
+      decimals: ASSETS_MAP.get("PINK")?.decimal,
+      id: ASSETS_MAP.get("PINK")?.id,
     },
   ],
   ecosystem: Ecosystem.Polkadot,


### PR DESCRIPTION
This issue aims to focus all the supported asset's metadata is a proper manner so that they can be distinguish and maintained properly. 

They type of asset should look like this - 

```ts
type Asset = {
  name: string;
  ticker: string;
  id: string;
  decimals: number;
  network: "substrate" | "evm"; // Some enum basically
};
```