### PR TITLE
THEA Withdrawals

### DIFF
--- a/.changeset/itchy-panthers-fly.md
+++ b/.changeset/itchy-panthers-fly.md
@@ -1,0 +1,13 @@
+---
+"@polkadex/thea": major
+---
+
+We have successfully added all the chains for cross chain transfer to Polkadex. In this task, we will be adding the withdraw logic for THEA so that user can withdraw thier assets from Polkadex network to other network.
+
+1. Polkadex to AssetHub - USDT, DED, PINK, USDC
+2. Polkadex to Astar - ASTR
+3. Polkadex to Moonbeam - GLMR
+4. Polkadex to Interlay - IBTC
+5. Polkadex to Unique - UNQ
+6. Polkadex to Polkadot - DOT
+7. Polkadex to Phala - PHA

--- a/apps/cross-chain/app/components/polkadotEco.tsx
+++ b/apps/cross-chain/app/components/polkadotEco.tsx
@@ -4,13 +4,13 @@ import { SubmittableExtrinsic } from "@polkadot/api/promise/types";
 import { Signer } from "@polkadot/api/types";
 import { getChainConnector, Thea } from "@polkadex/thea";
 
-const SOURCE_CHAIN = "Polkadot";
-const DESTINATION_CHAIN = "Polkadex";
-const SELECTED_ASSET = "DOT";
+const SOURCE_CHAIN = "Polkadex";
+const DESTINATION_CHAIN = "AssetHub";
+const SELECTED_ASSET = "USDT";
 
 const fromAddress = "5GLFKUxSXTf8MDDKM1vqEFb5TuV1q642qpQT964mrmjeKz4w";
 const toAddress = "5GLFKUxSXTf8MDDKM1vqEFb5TuV1q642qpQT964mrmjeKz4w";
-const amount = 0.01;
+const amount = 0.1;
 
 export const PolkadotEco = () => {
   const { getAllChains } = new Thea();

--- a/packages/thea/src/config/substrate/builders/ExtrinsicBuilder.ts
+++ b/packages/thea/src/config/substrate/builders/ExtrinsicBuilder.ts
@@ -2,6 +2,7 @@ import { polkadotXcm } from "./pallets/polkadotXcm";
 import { xcmPallet } from "./pallets/xcmPallet";
 import { xTokens } from "./pallets/xTokens";
 import { xTransfer } from "./pallets/xTransfer";
+import { theaExecuter } from "./pallets/theaExecuter";
 
 export function ExtrinsicBuilderV2() {
   return {
@@ -9,5 +10,6 @@ export function ExtrinsicBuilderV2() {
     xTransfer,
     xcmPallet,
     polkadotXcm,
+    theaExecuter,
   };
 }

--- a/packages/thea/src/config/substrate/builders/pallets/theaExecuter.ts
+++ b/packages/thea/src/config/substrate/builders/pallets/theaExecuter.ts
@@ -34,6 +34,29 @@ const parachainWithdraw = () => {
             },
           }),
       }),
+      insufficient: (
+        feeAssetId: string,
+        feeAmount: number
+      ): ExtrinsicConfigBuilder => ({
+        build: ({ address, amount, asset, destination }) =>
+          new ExtrinsicConfig({
+            module: pallet,
+            func,
+            getArgs: () => {
+              const version = XcmVersion.v3;
+              const account = getExtrinsicAccount(address);
+              return [
+                asset,
+                amount,
+                toBeneficiary(version, destination, account),
+                feeAssetId,
+                feeAmount,
+                true,
+                false,
+              ];
+            },
+          }),
+      }),
     }),
   };
 };

--- a/packages/thea/src/config/substrate/builders/pallets/theaExecuter.ts
+++ b/packages/thea/src/config/substrate/builders/pallets/theaExecuter.ts
@@ -1,0 +1,45 @@
+import {
+  XcmVersion,
+  ExtrinsicConfigBuilder,
+  ExtrinsicConfig,
+} from "@moonbeam-network/xcm-builder";
+
+import { getExtrinsicAccount } from "../ExtrinsicBuilder.utils";
+
+import { toBeneficiary } from "./theaExecuter.utils";
+
+const pallet = "theaExecutor";
+
+const parachainWithdraw = () => {
+  const func = "parachainWithdraw";
+  return {
+    X2: () => ({
+      sufficient: (): ExtrinsicConfigBuilder => ({
+        build: ({ address, amount, asset, destination }) =>
+          new ExtrinsicConfig({
+            module: pallet,
+            func,
+            getArgs: () => {
+              const version = XcmVersion.v3;
+              const account = getExtrinsicAccount(address);
+              return [
+                asset,
+                amount,
+                toBeneficiary(version, destination, account),
+                null,
+                null,
+                true,
+                false,
+              ];
+            },
+          }),
+      }),
+    }),
+  };
+};
+
+export const theaExecuter = () => {
+  return {
+    parachainWithdraw,
+  };
+};

--- a/packages/thea/src/config/substrate/builders/pallets/theaExecuter.utils.ts
+++ b/packages/thea/src/config/substrate/builders/pallets/theaExecuter.utils.ts
@@ -1,0 +1,22 @@
+import { XcmVersion } from "@moonbeam-network/xcm-builder";
+import { AnyChain } from "@moonbeam-network/xcm-types";
+
+export const toBeneficiary = (
+  version: XcmVersion,
+  destination: AnyChain,
+  account: any
+) => {
+  return {
+    [version]: {
+      parents: 1,
+      interior: {
+        X2: [
+          {
+            Parachain: destination.parachainId,
+          },
+          account,
+        ],
+      },
+    },
+  };
+};

--- a/packages/thea/src/config/substrate/builders/pallets/theaExecuter.utils.ts
+++ b/packages/thea/src/config/substrate/builders/pallets/theaExecuter.utils.ts
@@ -6,6 +6,17 @@ export const toBeneficiary = (
   destination: AnyChain,
   account: any
 ) => {
+  if (destination.key === "polkadot") {
+    return {
+      [version]: {
+        parents: 1,
+        interior: {
+          X1: account,
+        },
+      },
+    };
+  }
+
   return {
     [version]: {
       parents: 1,

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -56,14 +56,15 @@ const toAssethub: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: assetHub,
     destinationFee: {
-      amount: 0.7,
+      amount: 0.05,
       asset: usdc,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()
-      .polkadotXcm()
-      .reserveTransferAssets()
-      .here(),
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
     min: AssetMinBuilder().assets().asset(),
     fee: {
       asset: pdex,
@@ -78,7 +79,7 @@ const toAssethub: AssetConfig[] = [
     destination: assetHub,
     destinationFee: {
       amount: 0.7,
-      asset: ded,
+      asset: usdt,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()
@@ -99,7 +100,7 @@ const toAssethub: AssetConfig[] = [
     destination: assetHub,
     destinationFee: {
       amount: 0.7,
-      asset: pink,
+      asset: usdt,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -149,14 +149,15 @@ const toAstar: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: astar,
     destinationFee: {
-      amount: 0,
+      amount: 0, // Not sure
       asset: astr,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()
-      .polkadotXcm()
-      .reserveTransferAssets()
-      .here(),
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
     min: AssetMinBuilder().assets().asset(),
     fee: {
       asset: pdex,

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -1,5 +1,6 @@
 import { ChainConfig, AssetConfig } from "@moonbeam-network/xcm-config";
 import { BalanceBuilder, AssetMinBuilder } from "@moonbeam-network/xcm-builder";
+import { ASSETS_MAP } from "@polkadex/polkadex-api";
 
 import {
   assetHub,
@@ -83,9 +84,10 @@ const toAssethub: AssetConfig[] = [
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()
-      .polkadotXcm()
-      .reserveTransferAssets()
-      .here(),
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .insufficient(ASSETS_MAP.get("USDT")?.id as string, 700000000000),
     min: AssetMinBuilder().assets().asset(),
     fee: {
       asset: pdex,

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -125,14 +125,15 @@ const toPolkadot: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: polkadot,
     destinationFee: {
-      amount: 0,
+      amount: 0, // Not sure
       asset: dot,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()
-      .polkadotXcm()
-      .reserveTransferAssets()
-      .here(),
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
     min: AssetMinBuilder().assets().asset(),
     fee: {
       asset: pdex,

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -245,14 +245,15 @@ const toInterlay: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: interlay,
     destinationFee: {
-      amount: 0,
+      amount: 0, // Not sure
       asset: ibtc,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()
-      .polkadotXcm()
-      .reserveTransferAssets()
-      .here(),
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
     min: AssetMinBuilder().assets().asset(),
     fee: {
       asset: pdex,

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -22,8 +22,11 @@ import {
   glmr,
   unq,
   ibtc,
+  pdex,
 } from "../assets";
 import { ExtrinsicBuilderV2 } from "../builders";
+
+const xcmDeliveryFeeAmount = 1;
 
 const toAssethub: AssetConfig[] = [
   new AssetConfig({
@@ -31,15 +34,21 @@ const toAssethub: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: assetHub,
     destinationFee: {
-      amount: 0.7,
+      amount: 0.05,
       asset: usdt,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()
-      .polkadotXcm()
-      .reserveTransferAssets()
-      .here(),
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
     min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
   }),
 
   new AssetConfig({
@@ -56,6 +65,11 @@ const toAssethub: AssetConfig[] = [
       .reserveTransferAssets()
       .here(),
     min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
   }),
 
   new AssetConfig({
@@ -72,6 +86,11 @@ const toAssethub: AssetConfig[] = [
       .reserveTransferAssets()
       .here(),
     min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
   }),
 
   new AssetConfig({
@@ -88,6 +107,11 @@ const toAssethub: AssetConfig[] = [
       .reserveTransferAssets()
       .here(),
     min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
   }),
 ];
 
@@ -106,6 +130,11 @@ const toPolkadot: AssetConfig[] = [
       .reserveTransferAssets()
       .here(),
     min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
   }),
 ];
 
@@ -124,6 +153,11 @@ const toAstar: AssetConfig[] = [
       .reserveTransferAssets()
       .here(),
     min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
   }),
 ];
 
@@ -142,6 +176,11 @@ const toPhala: AssetConfig[] = [
       .reserveTransferAssets()
       .here(),
     min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
   }),
 ];
 
@@ -160,6 +199,11 @@ const toMoonbeam: AssetConfig[] = [
       .reserveTransferAssets()
       .here(),
     min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
   }),
 ];
 
@@ -178,6 +222,11 @@ const toUnique: AssetConfig[] = [
       .reserveTransferAssets()
       .here(),
     min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
   }),
 ];
 
@@ -196,6 +245,11 @@ const toInterlay: AssetConfig[] = [
       .reserveTransferAssets()
       .here(),
     min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
   }),
 ];
 

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -106,9 +106,10 @@ const toAssethub: AssetConfig[] = [
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()
-      .polkadotXcm()
-      .reserveTransferAssets()
-      .here(),
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .insufficient(ASSETS_MAP.get("USDT")?.id as string, 700000000000),
     min: AssetMinBuilder().assets().asset(),
     fee: {
       asset: pdex,

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -221,14 +221,15 @@ const toUnique: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: unique,
     destinationFee: {
-      amount: 0,
+      amount: 0, // Not sure
       asset: unq,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()
-      .polkadotXcm()
-      .reserveTransferAssets()
-      .here(),
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
     min: AssetMinBuilder().assets().asset(),
     fee: {
       asset: pdex,

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -173,14 +173,15 @@ const toPhala: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: phala,
     destinationFee: {
-      amount: 0,
+      amount: 0, // Not sure
       asset: pha,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()
-      .polkadotXcm()
-      .reserveTransferAssets()
-      .here(),
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
     min: AssetMinBuilder().assets().asset(),
     fee: {
       asset: pdex,

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -125,7 +125,7 @@ const toPolkadot: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: polkadot,
     destinationFee: {
-      amount: 0, // Not sure
+      amount: 0, // TODO: Change it later
       asset: dot,
       balance: BalanceBuilder().substrate().system().account(),
     },
@@ -149,7 +149,7 @@ const toAstar: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: astar,
     destinationFee: {
-      amount: 0, // Not sure
+      amount: 0, // TODO: Change it later
       asset: astr,
       balance: BalanceBuilder().substrate().system().account(),
     },
@@ -173,7 +173,7 @@ const toPhala: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: phala,
     destinationFee: {
-      amount: 0, // Not sure
+      amount: 0, // TODO: Change it later
       asset: pha,
       balance: BalanceBuilder().substrate().system().account(),
     },
@@ -197,7 +197,7 @@ const toMoonbeam: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: moonbeam,
     destinationFee: {
-      amount: 0, // Not sure
+      amount: 0, // TODO: Change it later
       asset: glmr,
       balance: BalanceBuilder().substrate().system().account(),
     },
@@ -221,7 +221,7 @@ const toUnique: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: unique,
     destinationFee: {
-      amount: 0, // Not sure
+      amount: 0, // TODO: Change it later
       asset: unq,
       balance: BalanceBuilder().substrate().system().account(),
     },
@@ -245,7 +245,7 @@ const toInterlay: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: interlay,
     destinationFee: {
-      amount: 0, // Not sure
+      amount: 0, // TODO: Change it later
       asset: ibtc,
       balance: BalanceBuilder().substrate().system().account(),
     },

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -197,14 +197,15 @@ const toMoonbeam: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: moonbeam,
     destinationFee: {
-      amount: 0,
+      amount: 0, // Not sure
       asset: glmr,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2()
-      .polkadotXcm()
-      .reserveTransferAssets()
-      .here(),
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
     min: AssetMinBuilder().assets().asset(),
     fee: {
       asset: pdex,


### PR DESCRIPTION
## Description

We have successfully added all the chains for cross chain transfer to Polkadex. In this task, we will be adding the withdraw logic for THEA so that user can withdraw thier assets from Polkadex network to other network.

1. Polkadex to AssetHub - [USDT](https://polkadex.subscan.io/extrinsic/0xc4cb8e4ae30adce6ecfdc7839f06517aed2ebee814a945c4b1c6141aa44a91bb), [DED](https://polkadex.subscan.io/extrinsic/0x4bb988eec25e6f260084b47ec1db73f41c3aadb1f23fb5fb50f31a97543d1cc6), PINK, USDC
2. Polkadex to Astar - ASTR
3. Polkadex to Moonbeam - GLMR
4. Polkadex to Interlay - IBTC
5. Polkadex to Unique - UNQ
6. Polkadex to Polkadot - DOT
7. Polkadex to Phala - PHA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability for users to withdraw assets from the Polkadex network to various other networks including AssetHub, Astar, Moonbeam, Interlay, Unique, Polkadot, and Phala.
  - Updated the asset and chain selection logic to enhance cross-chain transactions, including changing the default transaction asset and amounts.

- **Enhancements**
  - Improved fee calculation and extrinsic methods for asset transfers, ensuring more accurate and efficient transaction processing across different blockchain networks.

- **Documentation**
  - Updated internal documentation and configurations to align with the new cross-chain functionalities and fee structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->