### PR TITLE
Progress Bar Fix

### DIFF
--- a/.changeset/empty-jokes-move.md
+++ b/.changeset/empty-jokes-move.md
@@ -1,0 +1,7 @@
+---
+"@polkadex/react-providers": minor
+"@polkadex/ux": minor
+---
+
+This changes in this PR handles the error events for blockchain gracefully and fixes the transaction status array. Along with that, there are minor changes in Progress bar component to fix it's statuses checks.  
+

--- a/packages/react-providers/src/TransactionManagerProvider/provider.tsx
+++ b/packages/react-providers/src/TransactionManagerProvider/provider.tsx
@@ -79,7 +79,12 @@ export const TransactionManagerProvider = ({
 
       setStQueue(updatedTxStatus);
 
-      if (!result || result.isError || result.status.isFinalized) {
+      if (
+        !result ||
+        result.isError ||
+        result.dispatchError ||
+        result.status.isFinalized
+      ) {
         // Drop transaction
         const validTxs = txRef.current.filter(
           (t) => t.hash.toHex().toString() !== hash
@@ -125,9 +130,9 @@ export const TransactionManagerProvider = ({
 
   useEffect(() => {
     if (txQueue.length) {
-      const started = txStatus.find(
-        (s) => s.status === "broadcasted" || s.status === "inblock"
-      );
+      const started = txStatus
+        .filter((s) => !s.error)
+        .find((s) => s.status === "broadcasted" || s.status === "inblock");
       if (!started) sendExtrinsicToChain(txQueue[0]);
     }
   }, [txStatus, txQueue, sendExtrinsicToChain]);

--- a/packages/ui/src/components/progressBar.tsx
+++ b/packages/ui/src/components/progressBar.tsx
@@ -122,45 +122,51 @@ const Card = ({
   status: StatusProps;
   vertical?: boolean;
 }>) => {
-  const { txStatus, currentTxStatus, completedStatus, ongoingStatus, error } =
-    useProgressBarProvider();
+  const { txStatus, ongoingStatus, error } = useProgressBarProvider();
 
   const completed = useMemo(
     () => !!txStatus?.find((e) => e.status === status),
     [txStatus, status]
   );
-  const ongoing = status === ongoingStatus;
-  const finished = currentTxStatus?.status === completedStatus;
-  const activeAppearance = completed ? "success" : "primary";
+
+  const ongoing = useMemo(() => {
+    if (ongoingStatus === "broadcasted") return status === "inblock";
+    if (ongoingStatus === "inblock") return status === "finalized";
+    if (ongoingStatus === "finalized") return false;
+    return true;
+  }, [ongoingStatus, status]);
+
   const hasError = ongoing && error;
 
   const IconComponent = useMemo(
     () =>
-      (completed && !ongoing) || finished ? (
+      completed ? (
         <RiCheckLine className="w-4 h-4 text-success-base" />
       ) : (
         <RiBox3Fill className="w-4 h-4 text-white" />
       ),
 
-    [completed, ongoing, finished]
+    [completed]
   );
 
   const IconRender = useMemo(
     () =>
-      ongoing && !vertical && !finished ? (
+      !vertical && ongoing ? (
         <Spinner.PulseRing className="w-4 h-4 text-primary" />
       ) : (
         IconComponent
       ),
-    [ongoing, finished, vertical, IconComponent]
+    [vertical, IconComponent, ongoing]
   );
-  const apperance = ongoing && !finished ? "base" : activeAppearance;
+
+  const activeAppearance = completed ? "success" : "primary";
+  const apperance = ongoing ? "base" : activeAppearance;
 
   return (
     <div
       className={classNames(
         "flex items-center flex-1",
-        !completed && "opacity-50",
+        !completed && !ongoing && "opacity-50",
         vertical
           ? "flex-col px-4 gap-3 py-3"
           : "gap-2 py-1 pl-2 pr-3 rounded-full bg-level-2"
@@ -224,7 +230,11 @@ const Maximized = ({ children }: { children: ReactNode }) => {
                   Having Trouble?
                 </Typography.Text>
                 <Typography.Text appearance="info" size="xs" asChild>
-                  <a href="/" target="_blank">
+                  <a
+                    href="https://t.me/Polkadex"
+                    target="_blank"
+                    rel="norefferar noreferrer"
+                  >
                     Get in touch
                   </a>
                 </Typography.Text>

--- a/packages/ui/src/components/progressBar.tsx
+++ b/packages/ui/src/components/progressBar.tsx
@@ -130,6 +130,7 @@ const Card = ({
   );
 
   const ongoing = useMemo(() => {
+    if (ongoingStatus === "ongoing") return status === "broadcasted";
     if (ongoingStatus === "broadcasted") return status === "inblock";
     if (ongoingStatus === "inblock") return status === "finalized";
     if (ongoingStatus === "finalized") return false;


### PR DESCRIPTION
## Description

In transfer page, there is a bug found by community member. The transaction finished but the new progress bar thing got stuck. User got the notification in the corner it finished and it appeared under history, but the progress bar is stuck like that.

User was transfering from from funding to trading account. He first tried to transfer too much (some funds were locked in staking) and got a token frozen error which was correct. Later he reduced the amount to below the transferable value and submitted again and that’s when the progress bar was stuck.

![image](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/404f2523-825d-4faa-ba4a-7381931e5f7b)

To recreate this issue - 
1. Generating a blockchain error first by transferring more amount what I have 
2. Do a actual transfer

https://github.com/Polkadex-Substrate/polkadex-ts/assets/65214523/77a634e2-7b54-452d-9957-6a26dd9642d3

This PR aims to fix these issues basically - 

1. ProgressBar should work no matter what was the previous transaction
2. `InBlock` and `Finalized` check in ProgressBar component should happen one after another. Currently, both are getting checked at same time.

## Screencast(s)

### `InBlock` & `Finalized` Status issue fix

https://github.com/Polkadex-Substrate/polkadex-ts/assets/65214523/01465c5c-53b9-4019-a7b0-fda176048351

### Progress Bar stuck issue fix

https://github.com/Polkadex-Substrate/polkadex-ts/assets/65214523/6f49fbd6-a6e5-4c56-a80b-501a7f6fb17c