### PR TITLE
Fix vDOT decimal

### DIFF
--- a/.changeset/clever-cobras-guess.md
+++ b/.changeset/clever-cobras-guess.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/polkadex-api": patch
+---
+
+vDOT token decimal fix

--- a/packages/polkadex-api/src/modules/constants.ts
+++ b/packages/polkadex-api/src/modules/constants.ts
@@ -89,7 +89,7 @@ export const ASSETS: Asset[] = [
     name: "vDOT",
     ticker: "VDOT",
     id: "313524628741076911470961827389955394913",
-    decimal: 10,
+    decimal: 12,
     network: AssetType.Substrate,
   },
 ];


### PR DESCRIPTION
Changed vDOT decimal from 10 to 12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the decimal value for the vDOT token from 10 to 12, ensuring accurate representation and calculations for this asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->