### PR TITLE
Added destination chain fee

### DIFF
--- a/.changeset/curvy-fireants-design.md
+++ b/.changeset/curvy-fireants-design.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/thea": patch
+---
+
+Added destination fees for XCM transactions

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -176,7 +176,7 @@ const toPhala: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: phala,
     destinationFee: {
-      amount: 0, // TODO: Change it later
+      amount: 0.064296,
       asset: pha,
       balance: BalanceBuilder().substrate().system().account(),
     },
@@ -200,7 +200,7 @@ const toMoonbeam: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: moonbeam,
     destinationFee: {
-      amount: 0, // TODO: Change it later
+      amount: 0.0035,
       asset: glmr,
       balance: BalanceBuilder().substrate().system().account(),
     },
@@ -224,7 +224,7 @@ const toUnique: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: unique,
     destinationFee: {
-      amount: 0, // TODO: Change it later
+      amount: 0,
       asset: unq,
       balance: BalanceBuilder().substrate().system().account(),
     },
@@ -248,9 +248,9 @@ const toInterlay: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: interlay,
     destinationFee: {
-      amount: 0, // TODO: Change it later
+      amount: 0.00000063,
       asset: ibtc,
-      balance: BalanceBuilder().substrate().system().account(),
+      balance: BalanceBuilder().substrate().tokens().accounts(),
     },
     extrinsic: ExtrinsicBuilderV2()
       .theaExecuter()
@@ -272,7 +272,7 @@ const toBifrost: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: bifrost,
     destinationFee: {
-      amount: 0, // TODO: Change it later
+      amount: 0.000563136,
       asset: bnc,
       balance: BalanceBuilder().substrate().system().account(),
     },
@@ -294,9 +294,9 @@ const toBifrost: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: bifrost,
     destinationFee: {
-      amount: 0, // TODO: Change it later
+      amount: 0.00000007,
       asset: vdot,
-      balance: BalanceBuilder().substrate().system().account(),
+      balance: BalanceBuilder().substrate().tokens().accounts(),
     },
     extrinsic: ExtrinsicBuilderV2()
       .theaExecuter()


### PR DESCRIPTION
## Description - 

Added destination chain fee for XCM transfer from Polkadex to other chains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced destination fees for XCM transactions in the app.
  
- **Updates**
  - Updated fee amounts for transactions involving various assets such as Phala, Moonbeam, Unique, Interlay, and Bifrost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->