### PR TITLE
PDEX transfer between Moonbeam and Polkadex

### DIFF
--- a/.changeset/neat-suits-hope.md
+++ b/.changeset/neat-suits-hope.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/thea": minor
+---
+
+Added support for PDEX transfer between Moonbeam and Polkadex

--- a/packages/thea/src/config/substrate/builders/pallets/theaExecuter.utils.ts
+++ b/packages/thea/src/config/substrate/builders/pallets/theaExecuter.utils.ts
@@ -33,5 +33,5 @@ export const toBeneficiary = (
 };
 
 export const toAsset = (asset: ChainAssetId) => {
-  return asset === "0" ? "Polkadex" : { Asset: asset };
+  return !asset || asset === "PDEX" ? "Polkadex" : { Asset: asset };
 };

--- a/packages/thea/src/config/substrate/builders/pallets/xTokens.ts
+++ b/packages/thea/src/config/substrate/builders/pallets/xTokens.ts
@@ -6,7 +6,7 @@ import {
 
 import { getExtrinsicAccount } from "../ExtrinsicBuilder.utils";
 
-import { toAsset, toDest } from "./xTokens.utils";
+import { toAsset, toDest, toEvmAsset } from "./xTokens.utils";
 
 const pallet = "xTokens";
 
@@ -48,7 +48,7 @@ const transfer = () => ({
 });
 
 const evmTransfer = (): ExtrinsicConfigBuilder => ({
-  build: ({ address, amount, destination }) =>
+  build: ({ address, amount, asset, destination }) =>
     new ExtrinsicConfig({
       module: pallet,
       func: "transfer",
@@ -56,7 +56,7 @@ const evmTransfer = (): ExtrinsicConfigBuilder => ({
         const version = XcmVersion.v2;
         const account = getExtrinsicAccount(address);
         return [
-          "SelfReserve",
+          toEvmAsset(asset),
           amount,
           toDest(version, destination, account),
           "Unlimited",

--- a/packages/thea/src/config/substrate/builders/pallets/xTokens.utils.ts
+++ b/packages/thea/src/config/substrate/builders/pallets/xTokens.utils.ts
@@ -1,5 +1,5 @@
 import { XcmVersion, Parents } from "@moonbeam-network/xcm-builder";
-import { AnyChain } from "@moonbeam-network/xcm-types";
+import { AnyChain, ChainAssetId } from "@moonbeam-network/xcm-types";
 
 export const toDest = (
   version: XcmVersion,
@@ -44,4 +44,8 @@ export const toAsset = (interior: any, amount: any, parents?: Parents) => {
       Fungible: amount,
     },
   };
+};
+
+export const toEvmAsset = (asset: ChainAssetId) => {
+  return !asset || asset === "GLMR" ? "SelfReserve" : { ForeignAsset: asset };
 };

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -169,6 +169,11 @@ export const moonbeam = new EvmParachain({
       asset: glmr,
       decimals: 18,
     },
+    {
+      asset: pdex,
+      decimals: 12,
+      id: "90225766094594282577230355136633846906",
+    },
   ],
   ecosystem: Ecosystem.Polkadot,
   genesisHash: MOONBEAM_GENESIS,

--- a/packages/thea/src/config/substrate/config/moonbeam.ts
+++ b/packages/thea/src/config/substrate/config/moonbeam.ts
@@ -3,7 +3,7 @@ import { BalanceBuilder } from "@moonbeam-network/xcm-builder";
 
 import { ExtrinsicBuilderV2 } from "../builders";
 import { moonbeam, polkadex } from "../chains";
-import { glmr } from "../assets";
+import { glmr, pdex } from "../assets";
 
 const toPolkadex: AssetConfig[] = [
   new AssetConfig({
@@ -13,6 +13,23 @@ const toPolkadex: AssetConfig[] = [
     destinationFee: {
       amount: 0,
       asset: glmr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),
+    fee: {
+      asset: glmr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+  }),
+
+  // Not tested yet
+  new AssetConfig({
+    asset: pdex,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: polkadex,
+    destinationFee: {
+      amount: 0,
+      asset: pdex,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),

--- a/packages/thea/src/config/substrate/config/moonbeam.ts
+++ b/packages/thea/src/config/substrate/config/moonbeam.ts
@@ -22,13 +22,12 @@ const toPolkadex: AssetConfig[] = [
     },
   }),
 
-  // Not tested yet
   new AssetConfig({
     asset: pdex,
     balance: BalanceBuilder().substrate().assets().account(),
     destination: polkadex,
     destinationFee: {
-      amount: 0,
+      amount: 0.0064,
       asset: pdex,
       balance: BalanceBuilder().substrate().system().account(),
     },

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -216,6 +216,27 @@ const toMoonbeam: AssetConfig[] = [
       xcmDeliveryFeeAmount,
     },
   }),
+
+  new AssetConfig({
+    asset: pdex,
+    balance: BalanceBuilder().substrate().system().account(),
+    destination: moonbeam,
+    destinationFee: {
+      amount: 0.013,
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2()
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
+  }),
 ];
 
 const toUnique: AssetConfig[] = [


### PR DESCRIPTION
## Description - 

As there are multiple cross-chain supports are available for different assets, We will be going to support PDEX token transfer between Moonbeam and Polkadex. In this way, PDEX can be transferred from Polkadex to Moonbeam and vice-versa.

Moonbeam to Polkadex - https://moonbeam.subscan.io/xcm_message/polkadot-a3705d105644c76cc20adfc28814fc820f400bb6

Polkadex to Moonbeam - https://polkadex-parachain.subscan.io/xcm_message/polkadot-a9241808fa44bc685d99c9f2895a6657549071c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for PDEX transfer between Moonbeam and Polkadex.
  - Introduced new configurations for PDEX asset in Moonbeam and Polkadex settings.

- **Improvements**
  - Enhanced asset handling logic by updating conditions for asset parameters.
  - Improved EVM transfer function with additional asset parameter for better flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->