### PR TITLE
Configured minimum amount for cross chain

### DIFF
--- a/.changeset/yellow-swans-hang.md
+++ b/.changeset/yellow-swans-hang.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/thea": patch
+---
+
+Defined minimum bridge amount for some cross-chain combinations

--- a/packages/thea/src/config/substrate/config/astar.ts
+++ b/packages/thea/src/config/substrate/config/astar.ts
@@ -27,7 +27,7 @@ const toPolkadex: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: polkadex,
     destinationFee: {
-      amount: 0.1,
+      amount: 0.05,
       asset: dot,
       balance: BalanceBuilder().substrate().system().account(),
     },
@@ -61,7 +61,7 @@ const toPolkadex: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: polkadex,
     destinationFee: {
-      amount: 0.1,
+      amount: 0,
       asset: unq,
       balance: BalanceBuilder().substrate().assets().account(),
     },
@@ -78,7 +78,7 @@ const toPolkadex: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: polkadex,
     destinationFee: {
-      amount: 0.2,
+      amount: 0.1,
       asset: pha,
       balance: BalanceBuilder().substrate().assets().account(),
     },
@@ -129,7 +129,7 @@ const toPolkadex: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: polkadex,
     destinationFee: {
-      amount: 0.000003,
+      amount: 0.00000063,
       asset: ibtc,
       balance: BalanceBuilder().substrate().assets().account(),
     },

--- a/packages/thea/src/config/substrate/config/interlay.ts
+++ b/packages/thea/src/config/substrate/config/interlay.ts
@@ -27,7 +27,7 @@ const toPolkadex: AssetConfig[] = [
     balance: BalanceBuilder().substrate().tokens().accounts(),
     destination: polkadex,
     destinationFee: {
-      amount: 0.1,
+      amount: 0.06,
       asset: dot,
       balance: BalanceBuilder().substrate().assets().account(),
     },
@@ -75,7 +75,7 @@ const toPolkadex: AssetConfig[] = [
     balance: BalanceBuilder().substrate().tokens().accounts(),
     destination: polkadex,
     destinationFee: {
-      amount: 0.00000008,
+      amount: 0.00000007,
       asset: vdot,
       balance: BalanceBuilder().substrate().tokens().accounts(),
     },

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -1,0 +1,19 @@
+// Note - We are configuring minimum amount for a cross-chain transfer here as @moonbeam/sdk doesn't support it natively.
+
+// Note - Ensure that the Chain and Asset ticker match the definitions provided in the configurations.
+
+type Config = Record<string, Record<string, number>>;
+
+const Interlay: Config = {
+  Polkadex: {
+    IBTC: 0.0000001,
+    DOT: 0.1,
+    GLMR: 0.1,
+    BNC: 0.01,
+    vDOT: 0.0001,
+  },
+};
+
+export const MIN_BRIDGE_AMOUNT: Record<string, Config> = {
+  Interlay,
+};

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -14,6 +14,20 @@ const Interlay: Config = {
   },
 };
 
+const Astar: Config = {
+  Polkadex: {
+    ASTR: 0.01,
+    DOT: 0.1,
+    GLMR: 0.15,
+    UNQ: 0.1,
+    PHA: 0.2,
+    IBTC: 0.000003,
+    BNC: 0.1,
+    vDOT: 0.1,
+  },
+};
+
 export const MIN_BRIDGE_AMOUNT: Record<string, Config> = {
   Interlay,
+  Astar,
 };

--- a/packages/thea/src/config/substrate/index.ts
+++ b/packages/thea/src/config/substrate/index.ts
@@ -1,4 +1,5 @@
 export * from "./config";
+export * from "./constants";
 export * from "./chains";
 export * from "./assets";
 export * from "./helpers";

--- a/packages/thea/src/sdk/substrate/astar.ts
+++ b/packages/thea/src/sdk/substrate/astar.ts
@@ -15,6 +15,7 @@ import {
   chainsMap,
   getSubstrateChain,
   getSubstrateAsset,
+  MIN_BRIDGE_AMOUNT,
 } from "../../config";
 import { AssetAmount, BaseChainAdapter, TransferConfig } from "../types";
 
@@ -102,9 +103,13 @@ export class Astar implements BaseChainAdapter {
 
     const min: AssetAmount = {
       ticker: transferConfig.source.min.originSymbol,
-      amount: +Utils.formatUnits(
-        transferConfig.source.min.amount,
-        transferConfig.source.min.decimals
+      amount: Math.max(
+        MIN_BRIDGE_AMOUNT[this.chain.name]?.[destChain.name]?.[asset.ticker] ||
+          0,
+        +Utils.formatUnits(
+          transferConfig.source.min.amount,
+          transferConfig.source.min.decimals
+        )
       ),
     };
 

--- a/packages/thea/src/sdk/substrate/interlay.ts
+++ b/packages/thea/src/sdk/substrate/interlay.ts
@@ -15,6 +15,7 @@ import {
   chainsMap,
   getSubstrateChain,
   getSubstrateAsset,
+  MIN_BRIDGE_AMOUNT,
 } from "../../config";
 import { AssetAmount, BaseChainAdapter, TransferConfig } from "../types";
 
@@ -102,9 +103,13 @@ export class Interlay implements BaseChainAdapter {
 
     const min: AssetAmount = {
       ticker: transferConfig.source.min.originSymbol,
-      amount: +Utils.formatUnits(
-        transferConfig.source.min.amount,
-        transferConfig.source.min.decimals
+      amount: Math.max(
+        MIN_BRIDGE_AMOUNT[this.chain.name]?.[destChain.name]?.[asset.ticker] ||
+          0,
+        +Utils.formatUnits(
+          transferConfig.source.min.amount,
+          transferConfig.source.min.decimals
+        )
       ),
     };
 


### PR DESCRIPTION
## Description 

In cross chain transfers, there is always a minimum amount to be transferred so that transfer never fail. We are defining it for some chains which are not being calculated correctly by `@moonbeam/sdk` package. Except this, minimum amount for other cross chain combinations are being calculated correctly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced minimum amounts for cross-chain transfers for different assets on Polkadex for Interlay and Astar configurations.

- **Improvements**
  - Adjusted destination fee amounts for various assets in Astar and Interlay configurations for more accurate fee calculations.

- **Enhancements**
  - Updated Astar and Interlay classes to use the new `MIN_BRIDGE_AMOUNT` for calculating minimum asset amounts before formatting units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->