### PR TITLE
Non native tokens transfer b/w Bifrost & Polkadex

### DIFF
--- a/.changeset/quiet-schools-doubt.md
+++ b/.changeset/quiet-schools-doubt.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/thea": minor
+---
+
+Added support for non-native assets from Bifrost to Polkadex

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -263,6 +263,11 @@ export const bifrost = new Parachain({
       metadataId: { Token2: 3 },
       decimals: 18,
     },
+    {
+      asset: glmr,
+      id: { Token2: 1 },
+      decimals: 18,
+    },
   ],
   ecosystem: Ecosystem.Polkadot,
   genesisHash: BIFROST_GENESIS,

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -257,6 +257,12 @@ export const bifrost = new Parachain({
       metadataId: { VToken2: 0 },
       decimals: 10,
     },
+    {
+      asset: astr,
+      id: { Token2: 3 },
+      metadataId: { Token2: 3 },
+      decimals: 18,
+    },
   ],
   ecosystem: Ecosystem.Polkadot,
   genesisHash: BIFROST_GENESIS,

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -258,6 +258,12 @@ export const bifrost = new Parachain({
       decimals: 10,
     },
     {
+      asset: dot,
+      id: { Token2: 0 },
+      metadataId: { Token2: 0 },
+      decimals: 10,
+    },
+    {
       asset: astr,
       id: { Token2: 3 },
       metadataId: { Token2: 3 },

--- a/packages/thea/src/config/substrate/config/bifrost.ts
+++ b/packages/thea/src/config/substrate/config/bifrost.ts
@@ -1,9 +1,9 @@
 import { AssetConfig, ChainConfig } from "@moonbeam-network/xcm-config";
-import { BalanceBuilder } from "@moonbeam-network/xcm-builder";
+import { BalanceBuilder, AssetMinBuilder } from "@moonbeam-network/xcm-builder";
 
 import { ExtrinsicBuilderV2 } from "../builders";
 import { bifrost, polkadex } from "../chains";
-import { bnc, vdot } from "../assets";
+import { bnc, vdot, astr } from "../assets";
 
 const toPolkadex: AssetConfig[] = [
   new AssetConfig({
@@ -16,6 +16,7 @@ const toPolkadex: AssetConfig[] = [
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2().xTokens().transfer().X3(),
+    min: AssetMinBuilder().assetRegistry().currencyMetadatas(),
     fee: {
       asset: bnc,
       balance: BalanceBuilder().substrate().system().account(),
@@ -32,6 +33,25 @@ const toPolkadex: AssetConfig[] = [
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2().xTokens().transfer().X3(),
+    min: AssetMinBuilder().assetRegistry().currencyMetadatas(),
+    fee: {
+      asset: bnc,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+  }),
+
+  // Need to test
+  new AssetConfig({
+    asset: astr,
+    balance: BalanceBuilder().substrate().tokens().accounts(),
+    destination: polkadex,
+    destinationFee: {
+      amount: 0.05,
+      asset: astr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2().xTokens().transfer().X3(),
+    min: AssetMinBuilder().assetRegistry().currencyMetadatas(),
     fee: {
       asset: bnc,
       balance: BalanceBuilder().substrate().system().account(),

--- a/packages/thea/src/config/substrate/config/bifrost.ts
+++ b/packages/thea/src/config/substrate/config/bifrost.ts
@@ -3,7 +3,7 @@ import { BalanceBuilder, AssetMinBuilder } from "@moonbeam-network/xcm-builder";
 
 import { ExtrinsicBuilderV2 } from "../builders";
 import { bifrost, polkadex } from "../chains";
-import { bnc, vdot, astr, glmr } from "../assets";
+import { bnc, vdot, astr, glmr, dot } from "../assets";
 
 const toPolkadex: AssetConfig[] = [
   new AssetConfig({
@@ -64,6 +64,23 @@ const toPolkadex: AssetConfig[] = [
     destinationFee: {
       amount: 0.0035,
       asset: glmr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2().xTokens().transfer().X3(),
+    min: AssetMinBuilder().assetRegistry().currencyMetadatas(),
+    fee: {
+      asset: bnc,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+  }),
+
+  new AssetConfig({
+    asset: dot,
+    balance: BalanceBuilder().substrate().tokens().accounts(),
+    destination: polkadex,
+    destinationFee: {
+      amount: 0.05,
+      asset: dot,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2().xTokens().transfer().X3(),

--- a/packages/thea/src/config/substrate/config/bifrost.ts
+++ b/packages/thea/src/config/substrate/config/bifrost.ts
@@ -3,7 +3,7 @@ import { BalanceBuilder, AssetMinBuilder } from "@moonbeam-network/xcm-builder";
 
 import { ExtrinsicBuilderV2 } from "../builders";
 import { bifrost, polkadex } from "../chains";
-import { bnc, vdot, astr } from "../assets";
+import { bnc, vdot, astr, glmr } from "../assets";
 
 const toPolkadex: AssetConfig[] = [
   new AssetConfig({
@@ -40,7 +40,6 @@ const toPolkadex: AssetConfig[] = [
     },
   }),
 
-  // Need to test
   new AssetConfig({
     asset: astr,
     balance: BalanceBuilder().substrate().tokens().accounts(),
@@ -48,6 +47,23 @@ const toPolkadex: AssetConfig[] = [
     destinationFee: {
       amount: 0.05,
       asset: astr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2().xTokens().transfer().X3(),
+    min: AssetMinBuilder().assetRegistry().currencyMetadatas(),
+    fee: {
+      asset: bnc,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+  }),
+
+  new AssetConfig({
+    asset: glmr,
+    balance: BalanceBuilder().substrate().tokens().accounts(),
+    destination: polkadex,
+    destinationFee: {
+      amount: 0.0035,
+      asset: glmr,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2().xTokens().transfer().X3(),

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -579,7 +579,7 @@ const toBifrost: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: bifrost,
     destinationFee: {
-      amount: 0.045,
+      amount: 0.05,
       asset: astr,
       balance: BalanceBuilder().substrate().tokens().accounts(),
     },
@@ -596,13 +596,12 @@ const toBifrost: AssetConfig[] = [
     },
   }),
 
-  // Need to test
   new AssetConfig({
     asset: glmr,
     balance: BalanceBuilder().substrate().assets().account(),
     destination: bifrost,
     destinationFee: {
-      amount: 0, // Need to change
+      amount: 0.0035,
       asset: glmr,
       balance: BalanceBuilder().substrate().tokens().accounts(),
     },

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -596,6 +596,29 @@ const toBifrost: AssetConfig[] = [
       xcmDeliveryFeeAmount,
     },
   }),
+
+  // Need to test
+  new AssetConfig({
+    asset: glmr,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: bifrost,
+    destinationFee: {
+      amount: 0, // Need to change
+      asset: glmr,
+      balance: BalanceBuilder().substrate().tokens().accounts(),
+    },
+    extrinsic: ExtrinsicBuilderV2()
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
+  }),
 ];
 
 export const polkadexConfig = new ChainConfig({

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -128,7 +128,7 @@ const toPolkadot: AssetConfig[] = [
     balance: BalanceBuilder().substrate().assets().account(),
     destination: polkadot,
     destinationFee: {
-      amount: 0.005,
+      amount: 0.05,
       asset: dot,
       balance: BalanceBuilder().substrate().system().account(),
     },
@@ -618,13 +618,12 @@ const toBifrost: AssetConfig[] = [
     },
   }),
 
-  // Need to test
   new AssetConfig({
     asset: dot,
     balance: BalanceBuilder().substrate().assets().account(),
     destination: bifrost,
     destinationFee: {
-      amount: 0, // Need to change
+      amount: 0.05,
       asset: dot,
       balance: BalanceBuilder().substrate().tokens().accounts(),
     },

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -574,13 +574,12 @@ const toBifrost: AssetConfig[] = [
     },
   }),
 
-  // Need to test
   new AssetConfig({
     asset: astr,
     balance: BalanceBuilder().substrate().assets().account(),
     destination: bifrost,
     destinationFee: {
-      amount: 0, // Need to change
+      amount: 0.045,
       asset: astr,
       balance: BalanceBuilder().substrate().tokens().accounts(),
     },

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -619,6 +619,29 @@ const toBifrost: AssetConfig[] = [
       xcmDeliveryFeeAmount,
     },
   }),
+
+  // Need to test
+  new AssetConfig({
+    asset: dot,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: bifrost,
+    destinationFee: {
+      amount: 0, // Need to change
+      asset: dot,
+      balance: BalanceBuilder().substrate().tokens().accounts(),
+    },
+    extrinsic: ExtrinsicBuilderV2()
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
+  }),
 ];
 
 export const polkadexConfig = new ChainConfig({

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -573,6 +573,29 @@ const toBifrost: AssetConfig[] = [
       xcmDeliveryFeeAmount,
     },
   }),
+
+  // Need to test
+  new AssetConfig({
+    asset: astr,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: bifrost,
+    destinationFee: {
+      amount: 0, // Need to change
+      asset: astr,
+      balance: BalanceBuilder().substrate().tokens().accounts(),
+    },
+    extrinsic: ExtrinsicBuilderV2()
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
+  }),
 ];
 
 export const polkadexConfig = new ChainConfig({

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -31,6 +31,7 @@ const Bifrost: Config = {
   Polkadex: {
     vDOT: 0.001,
     ASTR: 0.1,
+    GLMR: 0.01,
   },
 };
 

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -32,6 +32,7 @@ const Bifrost: Config = {
     vDOT: 0.001,
     ASTR: 0.1,
     GLMR: 0.01,
+    DOT: 0.1,
   },
 };
 

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -27,7 +27,15 @@ const Astar: Config = {
   },
 };
 
+const Bifrost: Config = {
+  Polkadex: {
+    vDOT: 0.001,
+    ASTR: 0.1,
+  },
+};
+
 export const MIN_BRIDGE_AMOUNT: Record<string, Config> = {
   Interlay,
   Astar,
+  Bifrost,
 };

--- a/packages/thea/src/sdk/substrate/bifrost.ts
+++ b/packages/thea/src/sdk/substrate/bifrost.ts
@@ -15,6 +15,7 @@ import {
   chainsMap,
   getSubstrateChain,
   getSubstrateAsset,
+  MIN_BRIDGE_AMOUNT,
 } from "../../config";
 import { AssetAmount, BaseChainAdapter, TransferConfig } from "../types";
 
@@ -102,9 +103,13 @@ export class Bifrost implements BaseChainAdapter {
 
     const min: AssetAmount = {
       ticker: transferConfig.source.min.originSymbol,
-      amount: +Utils.formatUnits(
-        transferConfig.source.min.amount,
-        transferConfig.source.min.decimals
+      amount: Math.max(
+        MIN_BRIDGE_AMOUNT[this.chain.name]?.[destChain.name]?.[asset.ticker] ||
+          0,
+        +Utils.formatUnits(
+          transferConfig.source.min.amount,
+          transferConfig.source.min.decimals
+        )
       ),
     };
 


### PR DESCRIPTION
## 📝 Description

As of now, we have successfully migrated exisiting THEA functionalities to `@polkadex/thea` package i.e. THEA deposits and withdrawals for existing chains and assets. This task is the second part of THEA enhancement task.

Now, our next goal is to allow depositing non-native assets of exisiting chains to Polkadex network and allow withdrawals from Polkadex network back to original chain.
For example, Astar supports DOT, GLMR and more assets which are already supported by Polkadex network, but we never integrated it frontend. Technically, Transfer for these assets should work. So, we will be testing and allowing these transfers.

In this task, we will be adding these assets for Bifrost & Polkadex network - 

- [x] Bifrost to Polkadex & vice versa
    - DOT
    - GLMR
    - ASTR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for new assets (`dot`, `astr`, `glmr`) in the Bifrost Parachain configuration.
  - Introduced new configurations and settings for the additional assets, including minimum amounts and destination fees.

- **Improvements**
  - Updated `MIN_BRIDGE_AMOUNT` to include specific values for `Polkadex` tokens.
  - Enhanced the `Bifrost` class to calculate minimum amounts using updated configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->