### PR TITLE
Non native tokens transfer b/w Moonbeam & Polkadex

### DIFF
--- a/.changeset/stale-seahorses-worry.md
+++ b/.changeset/stale-seahorses-worry.md
@@ -1,0 +1,5 @@
+---
+"@polkadex/thea": minor
+---
+
+Added support for non-native assets of Moonbeam from Moonbeam to Polkadex and vice-versa

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -231,6 +231,11 @@ export const moonbeam = new EvmParachain({
       decimals: 12,
       id: "90225766094594282577230355136633846906",
     },
+    {
+      asset: dot,
+      decimals: 10,
+      id: "42259045809535163221576417993425387648",
+    },
   ],
   ecosystem: Ecosystem.Polkadot,
   genesisHash: MOONBEAM_GENESIS,

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -236,6 +236,11 @@ export const moonbeam = new EvmParachain({
       decimals: 10,
       id: "42259045809535163221576417993425387648",
     },
+    {
+      asset: astr,
+      decimals: 18,
+      id: "224077081838586484055667086558292981199",
+    },
   ],
   ecosystem: Ecosystem.Polkadot,
   genesisHash: MOONBEAM_GENESIS,

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -246,6 +246,11 @@ export const moonbeam = new EvmParachain({
       decimals: 12,
       id: "132685552157663328694213725410064821485",
     },
+    {
+      asset: bnc,
+      decimals: 12,
+      id: "165823357460190568952172802245839421906",
+    },
   ],
   ecosystem: Ecosystem.Polkadot,
   genesisHash: MOONBEAM_GENESIS,

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -256,6 +256,11 @@ export const moonbeam = new EvmParachain({
       decimals: 10,
       id: "29085784439601774464560083082574142143",
     },
+    {
+      asset: ibtc,
+      decimals: 8,
+      id: "120637696315203257380661607956669368914",
+    },
   ],
   ecosystem: Ecosystem.Polkadot,
   genesisHash: MOONBEAM_GENESIS,

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -251,6 +251,11 @@ export const moonbeam = new EvmParachain({
       decimals: 12,
       id: "165823357460190568952172802245839421906",
     },
+    {
+      asset: vdot,
+      decimals: 10,
+      id: "29085784439601774464560083082574142143",
+    },
   ],
   ecosystem: Ecosystem.Polkadot,
   genesisHash: MOONBEAM_GENESIS,

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -241,6 +241,11 @@ export const moonbeam = new EvmParachain({
       decimals: 18,
       id: "224077081838586484055667086558292981199",
     },
+    {
+      asset: pha,
+      decimals: 12,
+      id: "132685552157663328694213725410064821485",
+    },
   ],
   ecosystem: Ecosystem.Polkadot,
   genesisHash: MOONBEAM_GENESIS,

--- a/packages/thea/src/config/substrate/chains.ts
+++ b/packages/thea/src/config/substrate/chains.ts
@@ -183,6 +183,12 @@ export const interlay = new Parachain({
       metadataId: 0,
     },
     {
+      asset: ibtc,
+      decimals: 8,
+      id: { Token: ibtc.originSymbol },
+      metadataId: 0,
+    },
+    {
       asset: dot,
       decimals: 10,
       id: { Token: dot.originSymbol },
@@ -192,12 +198,6 @@ export const interlay = new Parachain({
       asset: glmr,
       decimals: 18,
       id: { ForeignAsset: 10 },
-      metadataId: 0,
-    },
-    {
-      asset: ibtc,
-      decimals: 8,
-      id: { Token: ibtc.originSymbol },
       metadataId: 0,
     },
     {

--- a/packages/thea/src/config/substrate/config/moonbeam.ts
+++ b/packages/thea/src/config/substrate/config/moonbeam.ts
@@ -3,7 +3,7 @@ import { BalanceBuilder, AssetMinBuilder } from "@moonbeam-network/xcm-builder";
 
 import { ExtrinsicBuilderV2 } from "../builders";
 import { moonbeam, polkadex } from "../chains";
-import { glmr, pdex, dot, astr, pha, bnc, vdot } from "../assets";
+import { glmr, pdex, dot, astr, pha, bnc, vdot, ibtc } from "../assets";
 
 const toPolkadex: AssetConfig[] = [
   new AssetConfig({
@@ -114,6 +114,23 @@ const toPolkadex: AssetConfig[] = [
     destinationFee: {
       amount: 0.00000007,
       asset: vdot,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: glmr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+  }),
+
+  new AssetConfig({
+    asset: ibtc,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: polkadex,
+    destinationFee: {
+      amount: 0.00000063,
+      asset: ibtc,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),

--- a/packages/thea/src/config/substrate/config/moonbeam.ts
+++ b/packages/thea/src/config/substrate/config/moonbeam.ts
@@ -3,7 +3,7 @@ import { BalanceBuilder, AssetMinBuilder } from "@moonbeam-network/xcm-builder";
 
 import { ExtrinsicBuilderV2 } from "../builders";
 import { moonbeam, polkadex } from "../chains";
-import { glmr, pdex, dot, astr, pha } from "../assets";
+import { glmr, pdex, dot, astr, pha, bnc } from "../assets";
 
 const toPolkadex: AssetConfig[] = [
   new AssetConfig({
@@ -80,6 +80,23 @@ const toPolkadex: AssetConfig[] = [
     destinationFee: {
       amount: 0.065,
       asset: pha,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: glmr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+  }),
+
+  new AssetConfig({
+    asset: bnc,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: polkadex,
+    destinationFee: {
+      amount: 0.0006,
+      asset: bnc,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),

--- a/packages/thea/src/config/substrate/config/moonbeam.ts
+++ b/packages/thea/src/config/substrate/config/moonbeam.ts
@@ -1,9 +1,9 @@
 import { AssetConfig, ChainConfig } from "@moonbeam-network/xcm-config";
-import { BalanceBuilder } from "@moonbeam-network/xcm-builder";
+import { BalanceBuilder, AssetMinBuilder } from "@moonbeam-network/xcm-builder";
 
 import { ExtrinsicBuilderV2 } from "../builders";
 import { moonbeam, polkadex } from "../chains";
-import { glmr, pdex } from "../assets";
+import { glmr, pdex, dot } from "../assets";
 
 const toPolkadex: AssetConfig[] = [
   new AssetConfig({
@@ -32,6 +32,24 @@ const toPolkadex: AssetConfig[] = [
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: glmr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+  }),
+
+  new AssetConfig({
+    asset: dot,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: polkadex,
+    destinationFee: {
+      amount: 0.05,
+      asset: dot,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),
+    min: AssetMinBuilder().assets().asset(),
     fee: {
       asset: glmr,
       balance: BalanceBuilder().substrate().system().account(),

--- a/packages/thea/src/config/substrate/config/moonbeam.ts
+++ b/packages/thea/src/config/substrate/config/moonbeam.ts
@@ -3,7 +3,7 @@ import { BalanceBuilder, AssetMinBuilder } from "@moonbeam-network/xcm-builder";
 
 import { ExtrinsicBuilderV2 } from "../builders";
 import { moonbeam, polkadex } from "../chains";
-import { glmr, pdex, dot, astr } from "../assets";
+import { glmr, pdex, dot, astr, pha } from "../assets";
 
 const toPolkadex: AssetConfig[] = [
   new AssetConfig({
@@ -63,6 +63,23 @@ const toPolkadex: AssetConfig[] = [
     destinationFee: {
       amount: 0.05,
       asset: astr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: glmr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+  }),
+
+  new AssetConfig({
+    asset: pha,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: polkadex,
+    destinationFee: {
+      amount: 0.065,
+      asset: pha,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),

--- a/packages/thea/src/config/substrate/config/moonbeam.ts
+++ b/packages/thea/src/config/substrate/config/moonbeam.ts
@@ -3,7 +3,7 @@ import { BalanceBuilder, AssetMinBuilder } from "@moonbeam-network/xcm-builder";
 
 import { ExtrinsicBuilderV2 } from "../builders";
 import { moonbeam, polkadex } from "../chains";
-import { glmr, pdex, dot, astr, pha, bnc } from "../assets";
+import { glmr, pdex, dot, astr, pha, bnc, vdot } from "../assets";
 
 const toPolkadex: AssetConfig[] = [
   new AssetConfig({
@@ -97,6 +97,23 @@ const toPolkadex: AssetConfig[] = [
     destinationFee: {
       amount: 0.0006,
       asset: bnc,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: glmr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+  }),
+
+  new AssetConfig({
+    asset: vdot,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: polkadex,
+    destinationFee: {
+      amount: 0.00000007,
+      asset: vdot,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),

--- a/packages/thea/src/config/substrate/config/moonbeam.ts
+++ b/packages/thea/src/config/substrate/config/moonbeam.ts
@@ -3,7 +3,7 @@ import { BalanceBuilder, AssetMinBuilder } from "@moonbeam-network/xcm-builder";
 
 import { ExtrinsicBuilderV2 } from "../builders";
 import { moonbeam, polkadex } from "../chains";
-import { glmr, pdex, dot } from "../assets";
+import { glmr, pdex, dot, astr } from "../assets";
 
 const toPolkadex: AssetConfig[] = [
   new AssetConfig({
@@ -46,6 +46,23 @@ const toPolkadex: AssetConfig[] = [
     destinationFee: {
       amount: 0.05,
       asset: dot,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: glmr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+  }),
+
+  new AssetConfig({
+    asset: astr,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: polkadex,
+    destinationFee: {
+      amount: 0.05,
+      asset: astr,
       balance: BalanceBuilder().substrate().system().account(),
     },
     extrinsic: ExtrinsicBuilderV2().xTokens().evmTransfer(),

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -392,13 +392,12 @@ const toMoonbeam: AssetConfig[] = [
     },
   }),
 
-  // Need to test
   new AssetConfig({
     asset: dot,
     balance: BalanceBuilder().substrate().assets().account(),
     destination: moonbeam,
     destinationFee: {
-      amount: 0, // Change it
+      amount: 0.05,
       asset: dot,
       balance: BalanceBuilder().substrate().system().account(),
     },

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -436,13 +436,12 @@ const toMoonbeam: AssetConfig[] = [
     },
   }),
 
-  // Need to test
   new AssetConfig({
     asset: pha,
     balance: BalanceBuilder().substrate().assets().account(),
     destination: moonbeam,
     destinationFee: {
-      amount: 0, // Change it
+      amount: 0.152,
       asset: pha,
       balance: BalanceBuilder().substrate().system().account(),
     },

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -506,6 +506,29 @@ const toMoonbeam: AssetConfig[] = [
       xcmDeliveryFeeAmount,
     },
   }),
+
+  // Need to test
+  new AssetConfig({
+    asset: ibtc,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: moonbeam,
+    destinationFee: {
+      amount: 0, // Change it
+      asset: ibtc,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2()
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
+  }),
 ];
 
 const toUnique: AssetConfig[] = [

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -483,6 +483,29 @@ const toMoonbeam: AssetConfig[] = [
       xcmDeliveryFeeAmount,
     },
   }),
+
+  // Need to test
+  new AssetConfig({
+    asset: vdot,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: moonbeam,
+    destinationFee: {
+      amount: 0, // Change it
+      asset: vdot,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2()
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
+  }),
 ];
 
 const toUnique: AssetConfig[] = [

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -458,13 +458,12 @@ const toMoonbeam: AssetConfig[] = [
     },
   }),
 
-  // Need to test
   new AssetConfig({
     asset: bnc,
     balance: BalanceBuilder().substrate().assets().account(),
     destination: moonbeam,
     destinationFee: {
-      amount: 0, // Change it
+      amount: 0.019,
       asset: bnc,
       balance: BalanceBuilder().substrate().system().account(),
     },

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -415,13 +415,12 @@ const toMoonbeam: AssetConfig[] = [
     },
   }),
 
-  // Need to test
   new AssetConfig({
     asset: astr,
     balance: BalanceBuilder().substrate().assets().account(),
     destination: moonbeam,
     destinationFee: {
-      amount: 0, // Change it
+      amount: 0.132,
       asset: astr,
       balance: BalanceBuilder().substrate().system().account(),
     },

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -480,13 +480,12 @@ const toMoonbeam: AssetConfig[] = [
     },
   }),
 
-  // Need to test
   new AssetConfig({
     asset: vdot,
     balance: BalanceBuilder().substrate().assets().account(),
     destination: moonbeam,
     destinationFee: {
-      amount: 0, // Change it
+      amount: 0.0011,
       asset: vdot,
       balance: BalanceBuilder().substrate().system().account(),
     },

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -414,6 +414,29 @@ const toMoonbeam: AssetConfig[] = [
       xcmDeliveryFeeAmount,
     },
   }),
+
+  // Need to test
+  new AssetConfig({
+    asset: astr,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: moonbeam,
+    destinationFee: {
+      amount: 0, // Change it
+      asset: astr,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2()
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
+  }),
 ];
 
 const toUnique: AssetConfig[] = [

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -437,6 +437,29 @@ const toMoonbeam: AssetConfig[] = [
       xcmDeliveryFeeAmount,
     },
   }),
+
+  // Need to test
+  new AssetConfig({
+    asset: pha,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: moonbeam,
+    destinationFee: {
+      amount: 0, // Change it
+      asset: pha,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2()
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
+  }),
 ];
 
 const toUnique: AssetConfig[] = [

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -502,13 +502,12 @@ const toMoonbeam: AssetConfig[] = [
     },
   }),
 
-  // Need to test
   new AssetConfig({
     asset: ibtc,
     balance: BalanceBuilder().substrate().assets().account(),
     destination: moonbeam,
     destinationFee: {
-      amount: 0, // Change it
+      amount: 0.00000084,
       asset: ibtc,
       balance: BalanceBuilder().substrate().system().account(),
     },

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -460,6 +460,29 @@ const toMoonbeam: AssetConfig[] = [
       xcmDeliveryFeeAmount,
     },
   }),
+
+  // Need to test
+  new AssetConfig({
+    asset: bnc,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: moonbeam,
+    destinationFee: {
+      amount: 0, // Change it
+      asset: bnc,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2()
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
+  }),
 ];
 
 const toUnique: AssetConfig[] = [

--- a/packages/thea/src/config/substrate/config/polkadex.ts
+++ b/packages/thea/src/config/substrate/config/polkadex.ts
@@ -391,6 +391,29 @@ const toMoonbeam: AssetConfig[] = [
       xcmDeliveryFeeAmount,
     },
   }),
+
+  // Need to test
+  new AssetConfig({
+    asset: dot,
+    balance: BalanceBuilder().substrate().assets().account(),
+    destination: moonbeam,
+    destinationFee: {
+      amount: 0, // Change it
+      asset: dot,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2()
+      .theaExecuter()
+      .parachainWithdraw()
+      .X2()
+      .sufficient(),
+    min: AssetMinBuilder().assets().asset(),
+    fee: {
+      asset: pdex,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
+  }),
 ];
 
 const toUnique: AssetConfig[] = [

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -27,7 +27,16 @@ const Astar: Config = {
   },
 };
 
+const Moonbeam: Config = {
+  Polkadex: {
+    PDEX: 0.1,
+    GLMR: 0.1,
+    DOT: 0.1,
+  },
+};
+
 export const MIN_BRIDGE_AMOUNT: Record<string, Config> = {
   Interlay,
   Astar,
+  Moonbeam,
 };

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -53,6 +53,7 @@ const Polkadex: Config = {
   Moonbeam: {
     ASTR: 0.2,
     DOT: 0.1,
+    PHA: 0.2,
   },
 };
 

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -49,9 +49,16 @@ const Moonbeam: Config = {
   },
 };
 
+const Polkadex: Config = {
+  Moonbeam: {
+    ASTR: 0.2,
+  },
+};
+
 export const MIN_BRIDGE_AMOUNT: Record<string, Config> = {
   Interlay,
   Astar,
   Bifrost,
   Moonbeam,
+  Polkadex,
 };

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -55,6 +55,7 @@ const Polkadex: Config = {
     DOT: 0.1,
     PHA: 0.2,
     BNC: 0.15,
+    vDOT: 0.01,
   },
 };
 

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -34,6 +34,7 @@ const Moonbeam: Config = {
     DOT: 0.1,
     ASTR: 0.1,
     PHA: 0.2,
+    BNC: 0.01,
   },
 };
 

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -56,6 +56,7 @@ const Polkadex: Config = {
     PHA: 0.2,
     BNC: 0.15,
     vDOT: 0.01,
+    IBTC: 0.000002,
   },
 };
 

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -52,6 +52,7 @@ const Moonbeam: Config = {
 const Polkadex: Config = {
   Moonbeam: {
     ASTR: 0.2,
+    DOT: 0.1,
   },
 };
 

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -35,6 +35,7 @@ const Moonbeam: Config = {
     ASTR: 0.1,
     PHA: 0.2,
     BNC: 0.01,
+    vDOT: 0.001,
   },
 };
 

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -32,6 +32,7 @@ const Moonbeam: Config = {
     PDEX: 0.1,
     GLMR: 0.1,
     DOT: 0.1,
+    ASTR: 0.1,
   },
 };
 

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -33,6 +33,7 @@ const Moonbeam: Config = {
     GLMR: 0.1,
     DOT: 0.1,
     ASTR: 0.1,
+    PHA: 0.2,
   },
 };
 

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -54,6 +54,7 @@ const Polkadex: Config = {
     ASTR: 0.2,
     DOT: 0.1,
     PHA: 0.2,
+    BNC: 0.15,
   },
 };
 

--- a/packages/thea/src/config/substrate/constants/index.ts
+++ b/packages/thea/src/config/substrate/constants/index.ts
@@ -36,6 +36,7 @@ const Moonbeam: Config = {
     PHA: 0.2,
     BNC: 0.01,
     vDOT: 0.001,
+    IBTC: 0.000003,
   },
 };
 

--- a/packages/thea/src/sdk/substrate/astar.ts
+++ b/packages/thea/src/sdk/substrate/astar.ts
@@ -4,6 +4,7 @@ import { Sdk } from "@moonbeam-network/xcm-sdk";
 import { ConfigService, ConfigBuilder } from "@moonbeam-network/xcm-config";
 import { AnyChain } from "@moonbeam-network/xcm-types";
 import { getPolkadotApi } from "@moonbeam-network/xcm-utils";
+import { parseScientific } from "@polkadex/numericals";
 
 import {
   Asset,
@@ -192,7 +193,7 @@ export class Astar implements BaseChainAdapter {
 
         const destAccountId = api.createType("AccountId32", toAddress).toHex();
         const amountFormatted = BigInt(
-          Utils.parseUnits(amount.toString(), asset.decimal)
+          Utils.parseUnits(parseScientific(amount.toString()), asset.decimal)
         );
 
         const palletInstance = this.chain.getAssetPalletInstance(

--- a/packages/thea/src/sdk/substrate/interlay.ts
+++ b/packages/thea/src/sdk/substrate/interlay.ts
@@ -4,6 +4,7 @@ import { Sdk } from "@moonbeam-network/xcm-sdk";
 import { ConfigService, ConfigBuilder } from "@moonbeam-network/xcm-config";
 import { AnyChain } from "@moonbeam-network/xcm-types";
 import { getPolkadotApi } from "@moonbeam-network/xcm-utils";
+import { parseScientific } from "@polkadex/numericals";
 
 import {
   Asset,
@@ -192,7 +193,7 @@ export class Interlay implements BaseChainAdapter {
 
         const destAccountId = api.createType("AccountId32", toAddress).toHex();
         const amountFormatted = BigInt(
-          Utils.parseUnits(amount.toString(), asset.decimal)
+          Utils.parseUnits(parseScientific(amount.toString()), asset.decimal)
         );
 
         const palletInstance = this.chain.getAssetPalletInstance(

--- a/packages/thea/src/sdk/substrate/moonbeam.ts
+++ b/packages/thea/src/sdk/substrate/moonbeam.ts
@@ -15,6 +15,7 @@ import {
   chainsMap,
   getSubstrateChain,
   getSubstrateAsset,
+  MIN_BRIDGE_AMOUNT,
 } from "../../config";
 import { AssetAmount, BaseChainAdapter, TransferConfig } from "../types";
 
@@ -102,9 +103,13 @@ export class Moonbeam implements BaseChainAdapter {
 
     const min: AssetAmount = {
       ticker: transferConfig.source.min.originSymbol,
-      amount: +Utils.formatUnits(
-        transferConfig.source.min.amount,
-        transferConfig.source.min.decimals
+      amount: Math.max(
+        MIN_BRIDGE_AMOUNT[this.chain.name]?.[destChain.name]?.[asset.ticker] ||
+          0,
+        +Utils.formatUnits(
+          transferConfig.source.min.amount,
+          transferConfig.source.min.decimals
+        )
       ),
     };
 

--- a/packages/thea/src/sdk/substrate/moonbeam.ts
+++ b/packages/thea/src/sdk/substrate/moonbeam.ts
@@ -4,6 +4,7 @@ import { Sdk } from "@moonbeam-network/xcm-sdk";
 import { ConfigService, ConfigBuilder } from "@moonbeam-network/xcm-config";
 import { AnyChain } from "@moonbeam-network/xcm-types";
 import { getPolkadotApi } from "@moonbeam-network/xcm-utils";
+import { parseScientific } from "@polkadex/numericals";
 
 import {
   Asset,
@@ -192,7 +193,7 @@ export class Moonbeam implements BaseChainAdapter {
 
         const destAccountId = api.createType("AccountId32", toAddress).toHex();
         const amountFormatted = BigInt(
-          Utils.parseUnits(amount.toString(), asset.decimal)
+          Utils.parseUnits(parseScientific(amount.toString()), asset.decimal)
         );
 
         const palletInstance = this.chain.getAssetPalletInstance(

--- a/packages/thea/src/sdk/substrate/polkadex.ts
+++ b/packages/thea/src/sdk/substrate/polkadex.ts
@@ -15,6 +15,7 @@ import {
   chainsMap,
   getSubstrateAsset,
   getSubstrateChain,
+  MIN_BRIDGE_AMOUNT,
 } from "../../config";
 import { AssetAmount, BaseChainAdapter, TransferConfig } from "../types";
 
@@ -102,9 +103,13 @@ export class Polkadex implements BaseChainAdapter {
 
     const min: AssetAmount = {
       ticker: transferConfig.source.min.originSymbol,
-      amount: +Utils.formatUnits(
-        transferConfig.source.min.amount,
-        transferConfig.source.min.decimals
+      amount: Math.max(
+        MIN_BRIDGE_AMOUNT[this.chain.name]?.[destChain.name]?.[asset.ticker] ||
+          0,
+        +Utils.formatUnits(
+          transferConfig.source.min.amount,
+          transferConfig.source.min.decimals
+        )
       ),
     };
 


### PR DESCRIPTION
## 📝 Description

As of now, we have successfully migrated exisiting THEA functionalities to `@polkadex/thea` package i.e. THEA deposits and withdrawals for existing chains and assets. This task is the second part of THEA enhancement task.

Now, our next goal is to allow depositing non-native assets of exisiting chains to Polkadex network and allow withdrawals from Polkadex network back to original chain.
For example, Moonbeam supports ASTR, IBTC and more assets which are already supported by Polkadex network, but we never integrated it frontend. Technically, Transfer for these assets should work. So, we will be testing and allowing these transfers.

In this task, we will be adding these assets for Moonbeam & Polkadex network - 

- [x] Moonbeam to Polkadex & vice versa
  - DOT ✅
  - IBTC ✅
  - PHA ✅
  - ASTR ✅
  - BNC ✅
  - vDOT ✅
    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional assets (`dot`, `astr`, `pha`, `bnc`, `vdot`, `ibtc`) on Moonbeam and Polkadex networks.
  
- **Enhancements**
  - Updated asset configurations to include detailed properties such as balances, destinations, fees, and extrinsic builders.
  - Improved minimum asset amount calculations using new configurations and `MIN_BRIDGE_AMOUNT`.

- **Bug Fixes**
  - Enhanced accuracy in unit parsing by integrating `parseScientific` for various asset operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->